### PR TITLE
Fix double-double quotes

### DIFF
--- a/concepts/concept-86.yaml
+++ b/concepts/concept-86.yaml
@@ -10,8 +10,8 @@ eng:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -52,8 +52,8 @@ eng:
               of all convex sets that contain the geometric object". Another
               definition in a Euclidean space `bbb"E"^n` is the union of all
               lines with both end points in the given geometric object. `C =
-              A.""convexHull"" <=> [C.""convex"" = ""TRUE""] ^^ [A sub C] ^^
-              [[B.""convex"" = ""true"", A sub B] => [A sube C sube B]]`
+              A."convexHull" <=> [C."convex" = "TRUE"] ^^ [A sub C] ^^
+              [[B."convex" = "true", A sub B] => [A sube C sube B]]`
           examples: []
           entry_status: valid
           review_indicator: ''
@@ -103,8 +103,8 @@ ara:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -156,8 +156,8 @@ ara:
               of all convex sets that contain the geometric object". Another
               definition in a Euclidean space `bbb"E"^n` is the union of all
               lines with both end points in the given geometric object. `C =
-              A.""convexHull"" <=> [C.""convex"" = ""TRUE""] ^^ [A sub C] ^^
-              [[B.""convex"" = ""true"", A sub B] => [A sube C sube B]]`
+              A."convexHull" <=> [C."convex" = "TRUE"] ^^ [A sub C] ^^
+              [[B."convex" = "true", A sub B] => [A sube C sube B]]`
           examples: []
           entry_status: valid
           review_indicator: ''
@@ -205,8 +205,8 @@ zho:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -319,8 +319,8 @@ fin:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -374,8 +374,8 @@ fin:
               of all convex sets that contain the geometric object". Another
               definition in a Euclidean space `bbb"E"^n` is the union of all
               lines with both end points in the given geometric object. `C =
-              A.""convexHull"" <=> [C.""convex"" = ""TRUE""] ^^ [A sub C] ^^
-              [[B.""convex"" = ""true"", A sub B] => [A sube C sube B]]`
+              A."convexHull" <=> [C."convex" = "TRUE"] ^^ [A sub C] ^^
+              [[B."convex" = "true", A sub B] => [A sube C sube B]]`
           examples: []
           entry_status: valid
           review_indicator: ''
@@ -483,8 +483,8 @@ deu:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -529,8 +529,8 @@ kor:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -580,8 +580,8 @@ kor:
               of all convex sets that contain the geometric object". Another
               definition in a Euclidean space `bbb"E"^n` is the union of all
               lines with both end points in the given geometric object. `C =
-              A.""convexHull"" <=> [C.""convex"" = ""TRUE""] ^^ [A sub C] ^^
-              [[B.""convex"" = ""true"", A sub B] => [A sube C sube B]]`
+              A."convexHull" <=> [C."convex" = "TRUE"] ^^ [A sub C] ^^
+              [[B."convex" = "true", A sub B] => [A sube C sube B]]`
           examples: []
           entry_status: valid
           review_indicator: ''
@@ -632,8 +632,8 @@ rus:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -687,8 +687,8 @@ rus:
               of all convex sets that contain the geometric object". Another
               definition in a Euclidean space `bbb"E"^n` is the union of all
               lines with both end points in the given geometric object. `C =
-              A.""convexHull"" <=> [C.""convex"" = ""TRUE""] ^^ [A sub C] ^^
-              [[B.""convex"" = ""true"", A sub B] => [A sube C sube B]]`
+              A."convexHull" <=> [C."convex" = "TRUE"] ^^ [A sub C] ^^
+              [[B."convex" = "true", A sub B] => [A sube C sube B]]`
           examples: []
           entry_status: valid
           review_indicator: ''
@@ -739,8 +739,8 @@ spa:
       measurement. The definition can be rewritten as "the intersection of all
       convex sets that contain the geometric object". Another definition in a
       Euclidean space `bbb"E"^n` is the union of all lines with both end points
-      in the given geometric object. `C = A.""convexHull"" <=> [C.""convex"" =
-      ""TRUE""] ^^ [A sub C] ^^ [[B.""convex"" = ""true"", A sub B] => [A sube C
+      in the given geometric object. `C = A."convexHull" <=> [C."convex" =
+      "TRUE"] ^^ [A sub C] ^^ [[B."convex" = "true", A sub B] => [A sube C
       sube B]]`
   examples: []
   entry_status: valid
@@ -792,8 +792,8 @@ spa:
               of all convex sets that contain the geometric object". Another
               definition in a Euclidean space `bbb"E"^n` is the union of all
               lines with both end points in the given geometric object. `C =
-              A.""convexHull"" <=> [C.""convex"" = ""TRUE""] ^^ [A sub C] ^^
-              [[B.""convex"" = ""true"", A sub B] => [A sube C sube B]]`
+              A."convexHull" <=> [C."convex" = "TRUE"] ^^ [A sub C] ^^
+              [[B."convex" = "true", A sub B] => [A sube C sube B]]`
           examples: []
           entry_status: valid
           review_indicator: ''


### PR DESCRIPTION
See https://github.com/geolexica/isotc211.geolexica.org/issues/138.

Concept 86 (convex hull) had some double-double quotes.  Some excessive escaping, perhaps?  Anyway, math renders broken because of that.

Needs review.