### PR TITLE
feat: Add register.yaml for Glossarist

### DIFF
--- a/register.yaml
+++ b/register.yaml
@@ -1,0 +1,25 @@
+---
+name: ISO/TC 211 Multi-Lingual Glossary of Terms
+
+description: >-
+  A compound register containing terminology records that have been
+  published in ISO/TC 211-sponsored International Standards and Technical Specifications.
+  Each spreadsheet constitutes a separate register. Each register contains the terminology
+  records in a nominated national or regional language.
+
+subregisters:
+  eng:
+  ara:
+  zho:
+  dan:
+  nld:
+  fin:
+  fra:
+  deu:
+  jpn:
+  kor:
+  msa:
+  pol:
+  rus:
+  spa:
+  swe:


### PR DESCRIPTION
(https://github.com/glossarist/glossarist-desktop/issues/30)

Adds `register.yaml`, a structure that will describe the register and subregisters for Glossarist (and/or other register management software).

* Replaces “languages” with “subregisters”
* The original metadata remains available in `tc211-termbase.meta.yaml`
* At this point schema is incomplete. So far it specifies register name, description, and only IDs of subregisters