### PR TITLE
add check for downstream repos dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     uses: geolexica/ci/.github/workflows/glossary-build.yml@main
 
   trigger-deploy:
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
     name: Trigger downstream repositories
     needs: build-release
     uses: geolexica/ci/.github/workflows/glossary-trigger.yml@main


### PR DESCRIPTION
Currently, the deployment was getting triggered for `isotc211.geolexica.org` every time a commit was added to any PR and it was failing. e.g -> https://github.com/geolexica/isotc211.geolexica.org/actions/runs/7136063729

So added the check to only trigger downstream repos when something is merged in main or staging or a tag is added.