### PR TITLE
fix: change center to centre

### DIFF
--- a/geolexica/localized-concept/417ee469-69c0-5961-ab59-5997c050594a.yaml
+++ b/geolexica/localized-concept/417ee469-69c0-5961-ab59-5997c050594a.yaml
@@ -7,7 +7,7 @@ data:
   - content: point in a stem:[n]-dimension coordinate system using stem:[n+1] numbers,
       latexmath:[([u_0, u_1, u_2, u_3, ... , u_n] \backepsilon [[0 \leq u_i \leq 1]
       \wedge \sum u_i = 1.0])], in which the location of a point of an n-simplex (of
-      any dimension) is specified by a weighted center of mass of equal masses placed
+      any dimension) is specified by a weighted centre of mass of equal masses placed
       at its vertices using vector algebra of the stem:[RR^n] used in the coordinate
       reference system
   examples: []


### PR DESCRIPTION
Change "center" which is in american english to british english "centre"

closes geolexica/isotc211.geolexica.org#215