### PR TITLE
updates to the mlgt register list

### DIFF
--- a/tc211-termbase.meta.yaml
+++ b/tc211-termbase.meta.yaml
@@ -105,12 +105,8 @@ languages:
       de l'ISO/TC 211
     date-of-last-change: '2020-06-02'
     submitting-organisation-name: AFNOR
-    submitting-organisation-contact: |-
-      a) Roxana Turcanu
-      b) Clément Drouadaine
-    submitting-organisation-contact-email: |-
-      a) roxana.turcanu@afnor.org
-      b) clement.drouadaine@ign.fr
+    submitting-organisation-contact: Clément Drouadaine
+    submitting-organisation-contact-email: clement.drouadaine@ign.fr
     submitting-organisation-contact-role: '002'
     uniform-resource-identifier-uri: https://www.afnor.org/
     operating-language-name: Français
@@ -118,12 +114,12 @@ languages:
     operating-language-country: '250'
     operating-language-character-encoding: '5'
   deu:
-    register-name: ISO/TC 211 Glossary of Terms - german
+    register-name: ISO/TC 211 Glossary of Terms - German
     content-summary: Eine Zusammenfassung der Begriffe aus den ISO/TC 211 Standards
     date-of-last-change: '2020-06-02'
     submitting-organisation-name: German mirror group to ISO/TC 211 (DIN)
-    submitting-organisation-contact: 
-    submitting-organisation-contact-email: 
+    submitting-organisation-contact: Chris Schubert
+    submitting-organisation-contact-email: chris.schubert@tuwien.ac.at
     submitting-organisation-contact-role: '002'
     uniform-resource-identifier-uri: 
     operating-language-name: German


### PR DESCRIPTION
from the 2024-11 TMG meeting:

one of the french members has left, their name was removed;

the german poc was updated to be Mr. Chris Schubert from TU Vienna after discussion with the German HoD Markus Seifert;

@HassanAkbar @ronaldtse i noticed a couple of the operating-language-character-encoding:  values were missing

also, in the future, do you  think we should have an english name for each of the registers as register-name: and content-summary: are often in the register language; for english searching it could be helpful to have register-name-en and content-summary-en;  but there is no hurry to consider this; not an enhancement request, only an idea for future work;

if my updates are ok, at your convenience, please push this to the main tc211 geolexica site.  thank you!