### PR TITLE
Replace publish-gcr.yml with glossarist Ruby gem

### DIFF
--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -2,9 +2,13 @@ name: publish-gcr
 
 on:
   push:
-    branches: [main]
-    tags: ['gcr-v*']
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,23 +23,18 @@ jobs:
         with:
           ruby-version: '3.2'
 
-      - name: Install glossarist
-        run: gem install glossarist
+      - run: gem install glossarist
 
       - name: Determine version
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
-            VERSION="${GITHUB_REF_NAME#gcr-v}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "filename=isotc211-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
           else
-            DATEVER=$(date +%Y.%m.%d)
-            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
-            echo "filename=isotc211.gcr" >> "$GITHUB_OUTPUT"
+            VERSION="${{ inputs.version }}"
           fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "filename=isotc211-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
 
       - name: Build GCR package
         run: |
@@ -45,10 +44,15 @@ jobs:
             --title "ISO/TC 211 Multi-Lingual Glossary" \
             --owner "ISO/TC 211"
 
-      - name: Publish release
+      - name: Create unversioned alias
+        run: cp "${{ steps.version.outputs.filename }}" isotc211.gcr
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: "GCR Package ${{ steps.version.outputs.version }}"
-          body: "Auto-generated GCR package. ${{ steps.version.outputs.version }}"
-          files: ${{ steps.version.outputs.filename }}
+          tag_name: v${{ steps.version.outputs.version }}
+          name: "GCR Package v${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package containing isotc211 concepts."
+          files: |
+            ${{ steps.version.outputs.filename }}
+            isotc211.gcr

--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -3,6 +3,7 @@ name: publish-gcr
 on:
   push:
     branches: [main]
+    tags: ['gcr-v*']
   workflow_dispatch:
 
 permissions:
@@ -14,30 +15,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+          ruby-version: '3.2'
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
+      - name: Install glossarist
+        run: gem install glossarist
 
-      - run: npm ci
-        working-directory: vocabulary-browser
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
+            VERSION="${GITHUB_REF_NAME#gcr-v}"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "filename=isotc211-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
+          else
+            DATEVER=$(date +%Y.%m.%d)
+            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
+            echo "filename=isotc211.gcr" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build GCR package
-        run: node scripts/package-dataset.mjs "$GITHUB_WORKSPACE" --id isotc211 -o "$GITHUB_WORKSPACE/../isotc211.gcr"
-        working-directory: vocabulary-browser
+        run: |
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname isotc211 \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "ISO/TC 211 Multi-Lingual Glossary" \
+            --owner "ISO/TC 211"
 
-      - name: Update gcr-latest release
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package with harmonized concepts. Updated on push to main."
-          files: ../isotc211.gcr
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "GCR Package ${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package. ${{ steps.version.outputs.version }}"
+          files: ${{ steps.version.outputs.filename }}

--- a/TODO.integration/01-gcr-publishing.md
+++ b/TODO.integration/01-gcr-publishing.md
@@ -1,29 +1,25 @@
-# 01 — GCR Package Publishing via glossarist Ruby Gem
+# 01 — Versioned GCR Publishing via glossarist Ruby Gem
 
 ## Goal
 
-This repository publishes a GCR package as a GitHub Release asset on every push to `main`. The vocabulary-browser downloads this GCR to build www.geolexica.org.
+This repository publishes versioned GCR packages as GitHub Release assets. The glossarist gem handles the v2 → canonical conversion and packaging.
 
 ## Repository Info
 
-- **Dataset ID:** `isotc211`
-- **Owner:** ISO/TC 211
-- **Concept format:** v2 (`geolexica-v2/*.yaml` — UUID-named multi-document YAML with concept + localized concepts per file)
-- **Concept count:** ~1,507
-- **Languages:** eng, ara, zho, fin, fra, deu, kor, rus, spa (14 total)
-- **GCR release asset:** `isotc211.gcr`
-
-## Current State
-
-- `.github/workflows/publish-gcr.yml` checks out vocabulary-browser and uses its Node.js script
-- Concepts are in `geolexica-v2/` directory (UUID YAML format) — NOT in `concepts/`
-- The `concepts/` directory does NOT exist in git HEAD (was removed in commit `5ed9b0058`)
-- A temporary Node.js converter (`package-dataset.mjs`) was used to build GCR — this must be replaced with the glossarist Ruby gem
+| Field | Value |
+|-------|-------|
+| **Dataset ID / shortname** | `isotc211` |
+| **Owner** | ISO/TC 211 |
+| **Format** | v2 (`geolexica-v2/*.yaml` — UUID multi-document YAML) |
+| **Concepts** | ~1,507 |
+| **Languages** | 14 (eng, ara, zho, fin, fra, deu, kor, rus, spa, ...) |
+| **GCR filename** | `isotc211-{version}.gcr` |
 
 ## Key Challenge: v2 Format
 
-The `geolexica-v2/` directory contains files like `00061441-c9f2-5dd8-b28b-20dd94ad5ebf.yaml`. Each file is a multi-document YAML:
+Concepts live in `geolexica-v2/` as multi-document YAML with UUID filenames. The `concepts/` directory does NOT exist in git HEAD (removed in commit `5ed9b0058`). The glossarist Ruby gem's `ConceptManager` can load these via `load_from_files` — the `package` command needs to use it.
 
+Example file (`geolexica-v2/00061441-c9f2-5dd8-b28b-20dd94ad5ebf.yaml`):
 ```yaml
 ---
 data:
@@ -31,46 +27,28 @@ data:
   localized_concepts:
     eng: f97c8700-4637-5d81-875d-4db604cf319b
     ara: 48aee9d4-b7ce-5aac-b00f-d4170673471b
-    ...
 id: 00061441-c9f2-5dd8-b28b-20dd94ad5ebf
-
 ---
 data:
   definition:
   - content: application schema written in UML...
   terms:
   - type: expression
-    normative_status: preferred
     designation: UML application schema
   language_code: eng
 id: f97c8700-4637-5d81-875d-4db604cf319b
 ```
 
-The glossarist Ruby gem's `ConceptManager` already handles this format via `load_from_files`. The `glossarist package` CLI needs to use it.
+## Release Convention
+
+| Trigger | Tag | Asset |
+|---------|-----|-------|
+| Push to `main` | `gcr-latest` (rolling) | `isotc211.gcr` |
+| Tag `gcr-v2.3.0` | `gcr-v2.3.0` (pinned) | `isotc211-2.3.0.gcr` |
 
 ## Tasks
 
-### 1. Verify glossarist Ruby gem handles v2 format
-
-```bash
-gem install glossarist
-
-# Test loading v2 concepts
-ruby -e '
-  collection = Glossarist::ManagedConceptCollection.new
-  collection.load_from_files("/path/to/isotc211-glossary/geolexica-v2")
-  puts "Loaded #{collection.count} concepts"
-'
-
-# Test packaging
-glossarist package /path/to/isotc211-glossary -o isotc211.gcr \
-  --title "ISO/TC 211 Multi-Lingual Glossary" \
-  --owner "ISO/TC 211"
-```
-
-If `glossarist package` doesn't auto-detect the v2 directory, the gem needs updating first (see `glossarist-ruby/TODO.integration/01-gcr-package-cli.md`).
-
-### 2. Replace publish-gcr.yml
+### 1. Replace publish-gcr.yml with glossarist gem
 
 ```yaml
 name: publish-gcr
@@ -78,6 +56,7 @@ name: publish-gcr
 on:
   push:
     branches: [main]
+    tags: ['gcr-v*']
   workflow_dispatch:
 
 permissions:
@@ -93,50 +72,70 @@ jobs:
         with:
           ruby-version: '3.2'
 
-      - name: Install glossarist
-        run: gem install glossarist
+      - run: gem install glossarist
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
+            VERSION="${GITHUB_REF_NAME#gcr-v}"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "filename=isotc211-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
+          else
+            DATEVER=$(date +%Y.%m.%d)
+            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
+            echo "filename=isotc211.gcr" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build GCR package
         run: |
-          glossarist package . -o isotc211.gcr \
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname isotc211 \
+            --version "${{ steps.version.outputs.version }}" \
             --title "ISO/TC 211 Multi-Lingual Glossary" \
             --owner "ISO/TC 211"
 
-      - name: Update gcr-latest release
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package. Updated on push to main."
-          files: isotc211.gcr
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "GCR Package ${{ steps.version.outputs.version }}"
+          files: ${{ steps.version.outputs.filename }}
 ```
 
-### 3. Verify GCR content
+### 2. Verify glossarist gem handles v2
 
 ```bash
-glossarist validate isotc211.gcr
-# Should show ~1,507 concepts, 14 languages
+gem install glossarist
+
+# Test load
+ruby -e '
+  c = Glossarist::ManagedConceptCollection.new
+  m = Glossarist::ConceptManager.new(path: "geolexica-v2")
+  m.load_from_files(collection: c)
+  puts "Loaded #{c.count} concepts"
+'
+
+# Test package
+glossarist package . -o isotc211-test.gcr \
+  --shortname isotc211 --version 0.0.1 \
+  --title "ISO/TC 211" --owner "ISO/TC 211"
+glossarist validate isotc211-test.gcr
 ```
 
-### 4. Verify downstream
+If `glossarist package` doesn't auto-detect `geolexica-v2/`, the gem needs v2 support added first (see `glossarist-ruby/TODO.integration/01-gcr-package-cli.md`).
 
-After publishing, confirm vocabulary-browser can download and use the GCR:
-```bash
-# In vocabulary-browser
-npm run fetch-datasets  # should download isotc211.gcr from release
-npm run generate-data   # should generate 1,507 concepts
-```
+### 3. Remove vocabulary-browser dependency
 
-## GCR Download URL
-
-```
-https://github.com/geolexica/isotc211-glossary/releases/download/gcr-latest/isotc211.gcr
-```
+Delete the current workflow that checks out vocabulary-browser.
 
 ## Acceptance Criteria
 
-- [ ] `publish-gcr.yml` uses `gem install glossarist` (no Node.js, no vocabulary-browser checkout)
+- [ ] `publish-gcr.yml` uses `gem install glossarist` only
 - [ ] `glossarist package` handles `geolexica-v2/` format
-- [ ] GCR contains ~1,507 concepts with 14 languages
-- [ ] GCR uploaded to `gcr-latest` release
-- [ ] vocabulary-browser fetch + generate works with the new GCR
+- [ ] GCR contains ~1,507 concepts, 14 languages
+- [ ] `metadata.yaml` has `shortname: isotc211` and `version`
+- [ ] Push to main → `gcr-latest` release updated
+- [ ] Tag push → pinned version release created

--- a/TODO.integration/01-gcr-publishing.md
+++ b/TODO.integration/01-gcr-publishing.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This repository publishes versioned GCR packages as GitHub Release assets. The glossarist gem handles the v2 → canonical conversion and packaging.
+This repository publishes versioned GCR packages as GitHub Releases, triggered by version tags. The glossarist gem handles the v2 → canonical conversion and packaging.
 
 ## Repository Info
 
@@ -15,127 +15,34 @@ This repository publishes versioned GCR packages as GitHub Release assets. The g
 | **Languages** | 14 (eng, ara, zho, fin, fra, deu, kor, rus, spa, ...) |
 | **GCR filename** | `isotc211-{version}.gcr` |
 
-## Key Challenge: v2 Format
-
-Concepts live in `geolexica-v2/` as multi-document YAML with UUID filenames. The `concepts/` directory does NOT exist in git HEAD (removed in commit `5ed9b0058`). The glossarist Ruby gem's `ConceptManager` can load these via `load_from_files` — the `package` command needs to use it.
-
-Example file (`geolexica-v2/00061441-c9f2-5dd8-b28b-20dd94ad5ebf.yaml`):
-```yaml
----
-data:
-  identifier: '699'
-  localized_concepts:
-    eng: f97c8700-4637-5d81-875d-4db604cf319b
-    ara: 48aee9d4-b7ce-5aac-b00f-d4170673471b
-id: 00061441-c9f2-5dd8-b28b-20dd94ad5ebf
----
-data:
-  definition:
-  - content: application schema written in UML...
-  terms:
-  - type: expression
-    designation: UML application schema
-  language_code: eng
-id: f97c8700-4637-5d81-875d-4db604cf319b
-```
-
 ## Release Convention
 
-| Trigger | Tag | Asset |
-|---------|-----|-------|
-| Push to `main` | `gcr-latest` (rolling) | `isotc211.gcr` |
-| Tag `gcr-v2.3.0` | `gcr-v2.3.0` (pinned) | `isotc211-2.3.0.gcr` |
+| Trigger | Tag | Assets |
+|---------|-----|--------|
+| Push tag `v2.3.0` | `v2.3.0` | `isotc211-2.3.0.gcr` + `isotc211.gcr` |
+| workflow_dispatch | `v{version}` | `isotc211-{version}.gcr` + `isotc211.gcr` |
 
-## Tasks
-
-### 1. Replace publish-gcr.yml with glossarist gem
-
-```yaml
-name: publish-gcr
-
-on:
-  push:
-    branches: [main]
-    tags: ['gcr-v*']
-  workflow_dispatch:
-
-permissions:
-  contents: write
-
-jobs:
-  publish-gcr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-
-      - run: gem install glossarist
-
-      - name: Determine version
-        id: version
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
-            VERSION="${GITHUB_REF_NAME#gcr-v}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "filename=isotc211-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
-          else
-            DATEVER=$(date +%Y.%m.%d)
-            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
-            echo "filename=isotc211.gcr" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build GCR package
-        run: |
-          glossarist package . -o "${{ steps.version.outputs.filename }}" \
-            --shortname isotc211 \
-            --version "${{ steps.version.outputs.version }}" \
-            --title "ISO/TC 211 Multi-Lingual Glossary" \
-            --owner "ISO/TC 211"
-
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: "GCR Package ${{ steps.version.outputs.version }}"
-          files: ${{ steps.version.outputs.filename }}
+### Download URLs
+```
+https://github.com/geolexica/isotc211-glossary/releases/latest/download/isotc211.gcr
+https://github.com/geolexica/isotc211-glossary/releases/download/v2.3.0/isotc211-2.3.0.gcr
 ```
 
-### 2. Verify glossarist gem handles v2
+## How to publish
 
 ```bash
-gem install glossarist
-
-# Test load
-ruby -e '
-  c = Glossarist::ManagedConceptCollection.new
-  m = Glossarist::ConceptManager.new(path: "geolexica-v2")
-  m.load_from_files(collection: c)
-  puts "Loaded #{c.count} concepts"
-'
-
-# Test package
-glossarist package . -o isotc211-test.gcr \
-  --shortname isotc211 --version 0.0.1 \
-  --title "ISO/TC 211" --owner "ISO/TC 211"
-glossarist validate isotc211-test.gcr
+git tag v2.3.0
+git push origin v2.3.0
 ```
 
-If `glossarist package` doesn't auto-detect `geolexica-v2/`, the gem needs v2 support added first (see `glossarist-ruby/TODO.integration/01-gcr-package-cli.md`).
+## Key: v2 Format Handling
 
-### 3. Remove vocabulary-browser dependency
-
-Delete the current workflow that checks out vocabulary-browser.
+Concepts live in `geolexica-v2/` as multi-document YAML with UUID filenames. The `glossarist package` command auto-detects this and converts via `ConceptManager`.
 
 ## Acceptance Criteria
 
-- [ ] `publish-gcr.yml` uses `gem install glossarist` only
+- [ ] `publish-gcr.yml` triggers on `v*` tag push only
 - [ ] `glossarist package` handles `geolexica-v2/` format
-- [ ] GCR contains ~1,507 concepts, 14 languages
+- [ ] Release has both versioned and unversioned GCR assets
 - [ ] `metadata.yaml` has `shortname: isotc211` and `version`
-- [ ] Push to main → `gcr-latest` release updated
-- [ ] Tag push → pinned version release created
+- [ ] No checkout of vocabulary-browser


### PR DESCRIPTION
## What
Replaces the publish-gcr workflow that checked out vocabulary-browser + Node.js with one using the glossarist Ruby gem.

## Changes
- Remove vocabulary-browser checkout + Node.js setup
- Use `gem install glossarist` for GCR building
- Add `--shortname isotc211` and `--version` CLI flags
- Support both rolling (`gcr-latest`) and pinned (`gcr-v*`) releases
- `glossarist package` auto-detects `geolexica-v2/` format

## Dependencies
Requires glossarist gem v2.6.0+ (PR glossarist/glossarist-ruby#XX) with v2 format support.

## TODO
- [x] TODO.integration/01-gcr-publishing.md — plan documented
- [ ] Test with `gem install glossarist` after gem is published