### PR TITLE
Fix validation compliance, add glossarist workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate concepts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - run: gem install glossarist
+
+      - name: Validate with glossarist
+        run: glossarist validate .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,25 @@ jobs:
 
       - name: Validate with glossarist
         run: glossarist validate .
+
+  test-package:
+    name: Test GCR package
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - run: gem install glossarist
+
+      - name: Test package build
+        run: |
+          glossarist package . -o test-isotc211.gcr \
+            --shortname isotc211 \
+            --version "0.0.0-test"
+
+      - name: Verify package
+        run: test -f test-isotc211.gcr && echo "Package built successfully"

--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -2,8 +2,13 @@ name: publish-gcr
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,30 +19,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+          ruby-version: '3.2'
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
+      - run: gem install glossarist
 
-      - run: npm ci
-        working-directory: vocabulary-browser
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "filename=isotc211-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
 
       - name: Build GCR package
-        run: node scripts/package-dataset.mjs "$GITHUB_WORKSPACE" --id isotc211 -o "$GITHUB_WORKSPACE/../isotc211.gcr"
-        working-directory: vocabulary-browser
+        run: |
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname isotc211 \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "ISO/TC 211 Geographic Information Vocabulary" \
+            --owner "ISO/TC 211"
 
-      - name: Update gcr-latest release
+      - name: Create unversioned alias
+        run: cp "${{ steps.version.outputs.filename }}" isotc211.gcr
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package with harmonized concepts. Updated on push to main."
-          files: ../isotc211.gcr
+          tag_name: v${{ steps.version.outputs.version }}
+          name: "GCR Package v${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package containing isotc211 concepts."
+          files: |
+            ${{ steps.version.outputs.filename }}
+            isotc211.gcr

--- a/geolexica-v2/0081babb-6cd1-5d63-b99a-6c24a09719f0.yaml
+++ b/geolexica-v2/0081babb-6cd1-5d63-b99a-6c24a09719f0.yaml
@@ -52,7 +52,7 @@ data:
   - type: expression
     designation: data quality value unit
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -88,7 +88,7 @@ data:
   - type: expression
     designation: وحدة قيمة جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -126,7 +126,7 @@ data:
   - type: expression
     designation: 数据质量值单位
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -165,7 +165,7 @@ data:
   - type: expression
     designation: værdienhed for datakvalitet
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -203,7 +203,7 @@ data:
   - type: expression
     designation: laatuarvon yksikkö
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -239,7 +239,7 @@ data:
   - type: expression
     designation: unité de valeur de qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -253,7 +253,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: '"metre"'
   id: '121'
@@ -277,7 +276,7 @@ data:
   - type: expression
     designation: Einheit der Datenqualitätsangabe
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -315,7 +314,7 @@ data:
   - type: expression
     designation: データ品質評価値単位
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -353,7 +352,7 @@ data:
   - type: expression
     designation: 데이터 품질 값 단위
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -430,7 +429,7 @@ data:
   - type: expression
     designation: единица измерения качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -469,7 +468,7 @@ data:
   - type: expression
     designation: unidad del valor de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -509,7 +508,7 @@ data:
   - type: expression
     designation: datakvalitetsresultatenhet
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/00abd3d6-9b89-5b8d-a5d3-f27d35bc5f95.yaml
+++ b/geolexica-v2/00abd3d6-9b89-5b8d-a5d3-f27d35bc5f95.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: trust
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: 신탁, 트러스트
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -120,7 +120,7 @@ data:
   - type: expression
     designation: kebolehpercayaan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -159,7 +159,7 @@ data:
   - type: expression
     designation: доверие
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -199,7 +199,7 @@ data:
   - type: expression
     designation: confianza
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/011ad37f-8a72-526e-aa44-0c28c417219f.yaml
+++ b/geolexica-v2/011ad37f-8a72-526e-aa44-0c28c417219f.yaml
@@ -160,7 +160,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '322'
   notes: []

--- a/geolexica-v2/027bdfa6-d2f6-53d6-bb73-7a9f480b2744.yaml
+++ b/geolexica-v2/027bdfa6-d2f6-53d6-bb73-7a9f480b2744.yaml
@@ -355,7 +355,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '146'
   notes:

--- a/geolexica-v2/031765e6-08eb-5c69-931f-6e2c60556bc4.yaml
+++ b/geolexica-v2/031765e6-08eb-5c69-931f-6e2c60556bc4.yaml
@@ -245,7 +245,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '18'
   notes:

--- a/geolexica-v2/03eed45b-5ae3-5bfd-81d1-9e4f64330bb1.yaml
+++ b/geolexica-v2/03eed45b-5ae3-5bfd-81d1-9e4f64330bb1.yaml
@@ -195,7 +195,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '664'
   notes:
@@ -263,7 +262,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '664'
   notes:

--- a/geolexica-v2/04a28888-486c-53d6-ab5a-e4974939b411.yaml
+++ b/geolexica-v2/04a28888-486c-53d6-ab5a-e4974939b411.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: relative positional accuracy
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: دقة الموقع النسبي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -104,7 +104,7 @@ data:
   - type: expression
     designation: 相对定位准确度
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -140,7 +140,7 @@ data:
   - type: expression
     designation: suhteellinen sijaintitarkkuus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -170,7 +170,7 @@ data:
   - type: expression
     designation: précision relative de postion
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -201,7 +201,7 @@ data:
   - type: expression
     designation: 상대 위치 정확도
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -234,7 +234,7 @@ data:
   - type: expression
     designation: относительная позиционная точность
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -267,7 +267,7 @@ data:
   - type: expression
     designation: exactitud posicional relativa
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -300,7 +300,7 @@ data:
   - type: expression
     designation: relativ lägesnoggrannhet
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)

--- a/geolexica-v2/04ea6a4b-34b2-549e-9d78-2616875badaf.yaml
+++ b/geolexica-v2/04ea6a4b-34b2-549e-9d78-2616875badaf.yaml
@@ -76,7 +76,6 @@ data:
   dates:
   - date: '2010-12-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: A server is generating a response to a GetFeature request, it has to
       copy a referenced feature into the response document and the server has to "relocate"

--- a/geolexica-v2/0522cb30-c618-5b72-9bd7-093ff902a9ae.yaml
+++ b/geolexica-v2/0522cb30-c618-5b72-9bd7-093ff902a9ae.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: persistent protection mechanism
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 지속적 보호 작동원리
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -113,7 +113,7 @@ data:
   - type: expression
     designation: механизм постоянной защиты
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -150,7 +150,7 @@ data:
   - type: expression
     designation: mecanismo de protección persistente
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/05471b63-8a80-5b95-bbbb-51bd41a257e8.yaml
+++ b/geolexica-v2/05471b63-8a80-5b95-bbbb-51bd41a257e8.yaml
@@ -169,7 +169,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '275'
   notes:

--- a/geolexica-v2/084f6ae3-b2e0-5fbc-af30-cb18061966e8.yaml
+++ b/geolexica-v2/084f6ae3-b2e0-5fbc-af30-cb18061966e8.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '874'
   notes: []

--- a/geolexica-v2/088eb1e8-7c1b-53cf-bf59-0b707873f105.yaml
+++ b/geolexica-v2/088eb1e8-7c1b-53cf-bf59-0b707873f105.yaml
@@ -182,7 +182,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '26'
   notes: []

--- a/geolexica-v2/097b4b15-54d7-5559-afff-f1ed3e945a38.yaml
+++ b/geolexica-v2/097b4b15-54d7-5559-afff-f1ed3e945a38.yaml
@@ -195,7 +195,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '252'
   notes: []

--- a/geolexica-v2/09baa04f-0709-5b6c-bdbc-30f2c8bc5416.yaml
+++ b/geolexica-v2/09baa04f-0709-5b6c-bdbc-30f2c8bc5416.yaml
@@ -35,7 +35,7 @@ data:
   - type: expression
     designation: terminological record identifier
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -64,7 +64,7 @@ data:
   - type: expression
     designation: معرِّف سجل مصطلحي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -93,7 +93,7 @@ data:
   - type: expression
     designation: 용어 레코드(기록) 식별자/확인자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: identificador de registro terminológico
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -182,7 +182,7 @@ data:
   - type: expression
     designation: terminological record identifier
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016

--- a/geolexica-v2/0a29204b-d713-5b71-be24-7a3e13dad5de.yaml
+++ b/geolexica-v2/0a29204b-d713-5b71-be24-7a3e13dad5de.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: robustness testing
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: اختبار المتانة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -101,7 +101,7 @@ data:
   - type: expression
     designation: 鲁棒性测试
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -132,7 +132,7 @@ data:
   - type: expression
     designation: vakaustestaus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: test de robustesse
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -192,7 +192,7 @@ data:
   - type: expression
     designation: 頑健性試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -222,7 +222,7 @@ data:
   - type: expression
     designation: 강도 시험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -253,7 +253,7 @@ data:
   - type: expression
     designation: проверка на устойчивость
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -284,7 +284,7 @@ data:
   - type: expression
     designation: prueba de robustez
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -316,7 +316,7 @@ data:
   - type: expression
     designation: robusthetstestning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/0a54e663-8f10-5c20-94d2-313543beb5da.yaml
+++ b/geolexica-v2/0a54e663-8f10-5c20-94d2-313543beb5da.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: lend
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: 대여
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: одалживать
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: prestar
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/0adce597-9ba7-5f5b-84ab-7e62238cdfc7.yaml
+++ b/geolexica-v2/0adce597-9ba7-5f5b-84ab-7e62238cdfc7.yaml
@@ -221,7 +221,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '83'
   notes:
@@ -282,7 +281,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '83'
   notes:

--- a/geolexica-v2/0aff053b-2c96-5572-a4a8-0bd754fa078d.yaml
+++ b/geolexica-v2/0aff053b-2c96-5572-a4a8-0bd754fa078d.yaml
@@ -206,7 +206,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '30'
   notes: []

--- a/geolexica-v2/0b13be28-c5dc-5f30-8f78-1809e657a0f3.yaml
+++ b/geolexica-v2/0b13be28-c5dc-5f30-8f78-1809e657a0f3.yaml
@@ -50,7 +50,7 @@ data:
   - type: expression
     designation: data quality measure
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -84,7 +84,7 @@ data:
   - type: expression
     designation: قياس جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -121,7 +121,7 @@ data:
   - type: expression
     designation: 数据质量度量
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -158,7 +158,7 @@ data:
   - type: expression
     designation: datakvalitet, mål for
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -195,7 +195,7 @@ data:
   - type: expression
     designation: laatumittari
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -231,7 +231,7 @@ data:
   - type: expression
     designation: mesure de qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -245,7 +245,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: The percentage of the values of an attribute that are correct.
   id: '115'
@@ -267,7 +266,7 @@ data:
   - type: expression
     designation: Datenqualitätsmaß
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -304,7 +303,7 @@ data:
   - type: expression
     designation: データ品質評価尺度
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -341,7 +340,7 @@ data:
   - type: expression
     designation: 데이터 품질 측정
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -414,7 +413,7 @@ data:
   - type: expression
     designation: мера качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -451,7 +450,7 @@ data:
   - type: expression
     designation: medida de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -490,7 +489,7 @@ data:
   - type: expression
     designation: datakvalitetsmått
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/0b36ed1f-4f30-595e-ad80-f28ce15e4e68.yaml
+++ b/geolexica-v2/0b36ed1f-4f30-595e-ad80-f28ce15e4e68.yaml
@@ -48,7 +48,7 @@ data:
   - type: expression
     designation: data quality date
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: تاريخ جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -117,7 +117,7 @@ data:
   - type: expression
     designation: 数据质量日期
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -153,7 +153,7 @@ data:
   - type: expression
     designation: datakvalitet, dato for
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -189,7 +189,7 @@ data:
   - type: expression
     designation: laatumittauksen päiväys
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -226,7 +226,7 @@ data:
   - type: expression
     designation: date de la qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -240,7 +240,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '112'
   notes: []
@@ -261,7 +260,7 @@ data:
   - type: expression
     designation: Datum der Datenqualitätsangabe
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -297,7 +296,7 @@ data:
   - type: expression
     designation: データ品質評価日付
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -333,7 +332,7 @@ data:
   - type: expression
     designation: 데이터 품질 일자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -404,7 +403,7 @@ data:
   - type: expression
     designation: период действия меры качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО19157:2013
@@ -441,7 +440,7 @@ data:
   - type: expression
     designation: fecha de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/0b669e01-b64e-5adf-88da-110810768e44.yaml
+++ b/geolexica-v2/0b669e01-b64e-5adf-88da-110810768e44.yaml
@@ -88,7 +88,6 @@ data:
     type: accepted
   - date: '2021-05-26T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '856'
   notes: []

--- a/geolexica-v2/0bed2a29-06b5-5f81-b5ad-caf9be53bd37.yaml
+++ b/geolexica-v2/0bed2a29-06b5-5f81-b5ad-caf9be53bd37.yaml
@@ -171,7 +171,6 @@ data:
     type: accepted
   - date: '2022-11-28T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '110'
   notes: []

--- a/geolexica-v2/0d12caff-62bf-512a-b68c-30129806c500.yaml
+++ b/geolexica-v2/0d12caff-62bf-512a-b68c-30129806c500.yaml
@@ -154,7 +154,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '323'
   notes: []

--- a/geolexica-v2/0e4baffd-a8c6-536a-b73a-545f3ebe5d3d.yaml
+++ b/geolexica-v2/0e4baffd-a8c6-536a-b73a-545f3ebe5d3d.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: expected risk
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 예상 위험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -90,7 +90,6 @@ data:
     type: accepted
   - date: '2019-08-30T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '1219'
   notes:
@@ -111,7 +110,7 @@ data:
   - type: expression
     designation: risiko jangkaan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -146,7 +145,7 @@ data:
   - type: expression
     designation: ожидаемый риск
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -182,7 +181,7 @@ data:
   - type: expression
     designation: riesgo esperado
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/0e9f01df-2100-5dd8-a5d6-506e331640c4.yaml
+++ b/geolexica-v2/0e9f01df-2100-5dd8-a5d6-506e331640c4.yaml
@@ -160,7 +160,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '47'
   notes: []

--- a/geolexica-v2/0f4b8ed5-0c15-5189-ab6b-10455bc753ef.yaml
+++ b/geolexica-v2/0f4b8ed5-0c15-5189-ab6b-10455bc753ef.yaml
@@ -48,7 +48,7 @@ data:
   - type: expression
     designation: behaviour <UML>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -85,7 +85,7 @@ data:
   - type: expression
     designation: سلوك <UML>
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -122,7 +122,7 @@ data:
   - type: expression
     designation: 行为<UML>
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: opførsel <UML>
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -197,7 +197,7 @@ data:
   - type: expression
     designation: käyttäytyminen <UML>
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -234,7 +234,7 @@ data:
   - type: expression
     designation: comportement <UML>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -248,7 +248,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '28'
   notes: []
@@ -270,7 +269,7 @@ data:
   - type: expression
     designation: Verhalten <UML>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -307,7 +306,7 @@ data:
   - type: expression
     designation: 행태 <UML>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -408,7 +407,7 @@ data:
   - type: expression
     designation: comportamiento <UML>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -445,7 +444,7 @@ data:
   - type: expression
     designation: behaviour <UML>
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015

--- a/geolexica-v2/0f8cf5db-e3c9-5476-8df3-75b94fff70e2.yaml
+++ b/geolexica-v2/0f8cf5db-e3c9-5476-8df3-75b94fff70e2.yaml
@@ -98,7 +98,6 @@ data:
     type: accepted
   - date: '2018-06-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '873'
   notes:

--- a/geolexica-v2/0fcfb449-f0f5-559b-a4a7-fd04578b3192.yaml
+++ b/geolexica-v2/0fcfb449-f0f5-559b-a4a7-fd04578b3192.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: infringement (of a right)
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -77,7 +77,7 @@ data:
   - type: expression
     designation: 저작권 침해
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -91,7 +91,6 @@ data:
     type: accepted
   - date: '2019-08-30T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '1228'
   notes:
@@ -112,7 +111,7 @@ data:
   - type: expression
     designation: pelanggaran hak
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -149,7 +148,7 @@ data:
   - type: expression
     designation: нарушение (права)
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -186,7 +185,7 @@ data:
   - type: expression
     designation: vulneración (de un derecho)
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/10029d34-9941-5173-b17d-adec4c98d919.yaml
+++ b/geolexica-v2/10029d34-9941-5173-b17d-adec4c98d919.yaml
@@ -98,7 +98,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '893'
   notes:

--- a/geolexica-v2/1025ed47-42b3-5e1c-91bf-fba1da09edb8.yaml
+++ b/geolexica-v2/1025ed47-42b3-5e1c-91bf-fba1da09edb8.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: resolution <coordinate>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-09-27T00:00:00+05:00'
   review_decision_date: '2022-09-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 6709:2022(E)
@@ -67,7 +67,7 @@ data:
   - type: expression
     designation: الوضوح (إحداثيات)
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-09-27T00:00:00+05:00'
   review_decision_date: '2022-09-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 6709:2022(E)
@@ -81,7 +81,6 @@ data:
     type: accepted
   - date: '2022-09-27T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '904'
   notes:
@@ -97,7 +96,7 @@ data:
   - type: expression
     designation: Auflösung  <Koordinate>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-09-27T00:00:00+05:00'
   review_decision_date: '2022-09-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 6709:2022(E)
@@ -128,7 +127,7 @@ data:
   - type: expression
     designation: 해상도<좌표>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-09-27T00:00:00+05:00'
   review_decision_date: '2022-09-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 6709:2022(E)
@@ -160,7 +159,7 @@ data:
   - type: expression
     designation: разрешение <координата>
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-09-27T00:00:00+05:00'
   review_decision_date: '2022-09-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 6709:2022(E)
@@ -191,7 +190,7 @@ data:
   - type: expression
     designation: resolución <coordenadas>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-09-27T00:00:00+05:00'
   review_decision_date: '2022-09-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 6709:2022(E)

--- a/geolexica-v2/10b1445a-c674-5270-9a9d-b7cc6c965376.yaml
+++ b/geolexica-v2/10b1445a-c674-5270-9a9d-b7cc6c965376.yaml
@@ -129,7 +129,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '2'
   notes: []

--- a/geolexica-v2/11360e42-8795-53a2-9643-8f3f645cdc8f.yaml
+++ b/geolexica-v2/11360e42-8795-53a2-9643-8f3f645cdc8f.yaml
@@ -243,7 +243,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '122'
   notes:

--- a/geolexica-v2/120b7a8b-e027-5ef1-b879-d2b66571855e.yaml
+++ b/geolexica-v2/120b7a8b-e027-5ef1-b879-d2b66571855e.yaml
@@ -76,7 +76,6 @@ data:
   dates:
   - date: '2011-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '800'
   notes:

--- a/geolexica-v2/121ef984-d432-52ba-8326-cdf9a71ad867.yaml
+++ b/geolexica-v2/121ef984-d432-52ba-8326-cdf9a71ad867.yaml
@@ -172,7 +172,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '363'
   notes: []

--- a/geolexica-v2/12dc7068-3840-5a01-9c2d-6fadb22d5456.yaml
+++ b/geolexica-v2/12dc7068-3840-5a01-9c2d-6fadb22d5456.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: GeoDRM enabled
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -72,7 +72,7 @@ data:
   - type: expression
     designation: GeoDRM 활성화
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -107,7 +107,7 @@ data:
   - type: expression
     designation: поддержка GeoDRM
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -142,7 +142,7 @@ data:
   - type: expression
     designation: GeoDRM activado
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/1355fd65-a5d9-5f13-ab84-76bda9490892.yaml
+++ b/geolexica-v2/1355fd65-a5d9-5f13-ab84-76bda9490892.yaml
@@ -310,7 +310,6 @@ data:
     type: accepted
   - date: '2019-01-31T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '763'
   notes:

--- a/geolexica-v2/135eefd2-67ba-57a2-9874-d567bb9fc936.yaml
+++ b/geolexica-v2/135eefd2-67ba-57a2-9874-d567bb9fc936.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: ring
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -73,7 +73,7 @@ data:
   - type: expression
     designation: حلقة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -103,7 +103,7 @@ data:
   - type: expression
     designation: 环
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -134,7 +134,7 @@ data:
   - type: expression
     designation: piiri
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -163,7 +163,7 @@ data:
   - type: expression
     designation: anneau
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -177,7 +177,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '385'
   notes:
@@ -193,7 +192,7 @@ data:
   - type: expression
     designation: Umring
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -223,7 +222,7 @@ data:
   - type: expression
     designation: 輪
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -253,7 +252,7 @@ data:
   - type: expression
     designation: 링
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -314,7 +313,7 @@ data:
   - type: expression
     designation: кольцо
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -345,7 +344,7 @@ data:
   - type: expression
     designation: anillo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -376,7 +375,7 @@ data:
   - type: expression
     designation: geometrisk ring
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/13905cf0-c7e8-5af0-8f64-f9a3c7c8f2a3.yaml
+++ b/geolexica-v2/13905cf0-c7e8-5af0-8f64-f9a3c7c8f2a3.yaml
@@ -50,7 +50,7 @@ data:
   - type: expression
     designation: data quality element
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -86,7 +86,7 @@ data:
   - type: expression
     designation: عنصر جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -123,7 +123,7 @@ data:
   - type: expression
     designation: 数据质量元素
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: datakvalitetselement
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -201,7 +201,7 @@ data:
   - type: expression
     designation: laatutekijä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -237,7 +237,7 @@ data:
   - type: expression
     designation: élément de qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -251,7 +251,6 @@ data:
     type: accepted
   - date: '2014-11-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '113'
   notes:
@@ -275,7 +274,7 @@ data:
   - type: expression
     designation: Datenqualitätselement
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -313,7 +312,7 @@ data:
   - type: expression
     designation: 데이터 품질 요소
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -352,7 +351,7 @@ data:
   - type: expression
     designation: элемент качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО19101-1:2014
@@ -392,7 +391,7 @@ data:
   - type: expression
     designation: elemento de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -433,7 +432,7 @@ data:
   - type: expression
     designation: datakvalitetsegenskap
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014

--- a/geolexica-v2/159e64c0-eea6-53fa-a512-a7c3db8558a1.yaml
+++ b/geolexica-v2/159e64c0-eea6-53fa-a512-a7c3db8558a1.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: contract
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: 계약
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -93,7 +93,6 @@ data:
     type: accepted
   - date: '2019-08-30T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '1215'
   notes: []
@@ -114,7 +113,7 @@ data:
   - type: expression
     designation: lekap
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -152,7 +151,7 @@ data:
   - type: expression
     designation: договор
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -190,7 +189,7 @@ data:
   - type: expression
     designation: contrato
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/17555a7a-65a2-55e4-949f-a0ca65e30faa.yaml
+++ b/geolexica-v2/17555a7a-65a2-55e4-949f-a0ca65e30faa.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: data element
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: عنصر بيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 数据元素
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: dataelement
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: tietoelementti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -224,7 +224,7 @@ data:
   - type: expression
     designation: élément de donnée
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -238,7 +238,6 @@ data:
     type: accepted
   - date: '2011-10-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '105'
   notes: []
@@ -259,7 +258,7 @@ data:
   - type: expression
     designation: Datenelement
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -295,7 +294,7 @@ data:
   - type: expression
     designation: 데이터 요소
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -332,7 +331,7 @@ data:
   - type: expression
     designation: элемент данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Публикация ИСО19118:2011
@@ -368,7 +367,7 @@ data:
   - type: expression
     designation: elemento de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011
@@ -405,7 +404,7 @@ data:
   - type: expression
     designation: dataelement
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-10-15T00:00:00+05:00'
   review_decision_date: '2011-10-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19118:2011

--- a/geolexica-v2/17bb25a3-5d32-5072-8241-46970da6ee80.yaml
+++ b/geolexica-v2/17bb25a3-5d32-5072-8241-46970da6ee80.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2009-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '851'
   notes:

--- a/geolexica-v2/1880f7f5-56fb-5954-b32b-2ab1d050d68f.yaml
+++ b/geolexica-v2/1880f7f5-56fb-5954-b32b-2ab1d050d68f.yaml
@@ -37,7 +37,7 @@ data:
   - type: expression
     designation: licensee
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: 사업자, 라이선시, 실사권자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -84,7 +84,6 @@ data:
     type: accepted
   - date: '2019-08-30T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '1235'
   notes: []
@@ -102,7 +101,7 @@ data:
   - type: expression
     designation: pemegang lesen
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -135,7 +134,7 @@ data:
   - type: expression
     designation: лицензиат
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -168,7 +167,7 @@ data:
   - type: expression
     designation: titular de la licencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/1895a329-382d-5c75-a139-bdd61c5677ec.yaml
+++ b/geolexica-v2/1895a329-382d-5c75-a139-bdd61c5677ec.yaml
@@ -241,7 +241,6 @@ data:
   dates:
   - date: '2000-12-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '235'
   notes:

--- a/geolexica-v2/189c57bb-041b-588b-b26b-6226eecd5ec9.yaml
+++ b/geolexica-v2/189c57bb-041b-588b-b26b-6226eecd5ec9.yaml
@@ -335,7 +335,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '135'
   notes: []

--- a/geolexica-v2/18f4fb5f-fd1b-52bc-82f9-9887ff043749.yaml
+++ b/geolexica-v2/18f4fb5f-fd1b-52bc-82f9-9887ff043749.yaml
@@ -205,7 +205,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '499'
   notes: []
@@ -274,7 +273,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '499'
   notes: []

--- a/geolexica-v2/197fa672-b9e8-5a2e-b3a3-cee53743e210.yaml
+++ b/geolexica-v2/197fa672-b9e8-5a2e-b3a3-cee53743e210.yaml
@@ -48,7 +48,7 @@ data:
   - type: expression
     designation: feature portrayal rule set
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: مجموعة قواعد عرض  المعالم
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -117,7 +117,7 @@ data:
   - type: expression
     designation: 要素图示表达规则集
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -153,7 +153,7 @@ data:
   - type: expression
     designation: featurevisualisering, regelsæt for
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -189,7 +189,7 @@ data:
   - type: expression
     designation: kohteen esittämissäännöt
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -226,7 +226,7 @@ data:
   - type: expression
     designation: jeu de règles de présentation d'une entité
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -263,7 +263,7 @@ data:
   - type: expression
     designation: Regelsammlung zur Feature-Darstellung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -301,7 +301,7 @@ data:
   - type: expression
     designation: 피처 묘화규칙 집합
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -373,7 +373,7 @@ data:
   - type: expression
     designation: набор правил отображения пространственных объектов
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19117:2012
@@ -410,7 +410,7 @@ data:
   - type: expression
     designation: conjunto de reglas de representación de objetos geográficos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -447,7 +447,7 @@ data:
   - type: expression
     designation: symboliseringsregel
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012

--- a/geolexica-v2/19f0edd2-d19b-55e2-84d7-a57f57c71424.yaml
+++ b/geolexica-v2/19f0edd2-d19b-55e2-84d7-a57f57c71424.yaml
@@ -79,7 +79,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '717'
   notes:

--- a/geolexica-v2/1a3ed092-b3d0-5d9a-939d-aaedb7d1bd5b.yaml
+++ b/geolexica-v2/1a3ed092-b3d0-5d9a-939d-aaedb7d1bd5b.yaml
@@ -170,7 +170,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1008'
   notes: []

--- a/geolexica-v2/1a5f8c0f-6a6e-55fe-a8f1-774ebfd04594.yaml
+++ b/geolexica-v2/1a5f8c0f-6a6e-55fe-a8f1-774ebfd04594.yaml
@@ -158,7 +158,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '391'
   notes: []

--- a/geolexica-v2/1af9728b-691a-5c93-80f2-b4a699d897ab.yaml
+++ b/geolexica-v2/1af9728b-691a-5c93-80f2-b4a699d897ab.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: abstract test method
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: طريقة اختبار تجريدي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -99,7 +99,7 @@ data:
   - type: expression
     designation: 抽象测试方法
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -128,7 +128,7 @@ data:
   - type: expression
     designation: abstrakt testmetode
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -157,7 +157,7 @@ data:
   - type: expression
     designation: abstrakti testausmenetelmä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -186,7 +186,7 @@ data:
   - type: expression
     designation: méthode de test abstrait
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -200,7 +200,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '4'
   notes: []
@@ -214,7 +213,7 @@ data:
   - type: expression
     designation: abstrakte Prüfmethode
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -243,7 +242,7 @@ data:
   - type: expression
     designation: 抽象試験方法
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -272,7 +271,7 @@ data:
   - type: expression
     designation: 추상 시험 방법
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -301,7 +300,7 @@ data:
   - type: expression
     designation: метод абстрактного теста
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -331,7 +330,7 @@ data:
   - type: expression
     designation: método de prueba abstracta
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -360,7 +359,7 @@ data:
   - type: expression
     designation: implementeringsoberoende testmetod
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/1c0e411b-10f4-5ff2-9cba-00238a0dd78a.yaml
+++ b/geolexica-v2/1c0e411b-10f4-5ff2-9cba-00238a0dd78a.yaml
@@ -197,7 +197,6 @@ data:
   dates:
   - date: '2005-08-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '337'
   notes: []

--- a/geolexica-v2/1d3cdc94-03bd-56da-be83-eec735a36dfb.yaml
+++ b/geolexica-v2/1d3cdc94-03bd-56da-be83-eec735a36dfb.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: copyleft
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -73,7 +73,7 @@ data:
   - type: expression
     designation: 카피레프트
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -109,7 +109,7 @@ data:
   - type: expression
     designation: copyleft
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -145,7 +145,7 @@ data:
   - type: expression
     designation: copyleft
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/1db1f645-cc2b-52fd-aae8-2d9b55c1465a.yaml
+++ b/geolexica-v2/1db1f645-cc2b-52fd-aae8-2d9b55c1465a.yaml
@@ -74,7 +74,6 @@ data:
   dates:
   - date: '2014-01-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1383'
   notes: []

--- a/geolexica-v2/1edd1ef0-be75-53aa-bb44-9ec4f3b6bd80.yaml
+++ b/geolexica-v2/1edd1ef0-be75-53aa-bb44-9ec4f3b6bd80.yaml
@@ -239,7 +239,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '210'
   notes:

--- a/geolexica-v2/1fa94a36-af3f-5ab7-b673-64dd6296f83d.yaml
+++ b/geolexica-v2/1fa94a36-af3f-5ab7-b673-64dd6296f83d.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: portrayal specification
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: مواصفات العرض
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 图示表达规范
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: esitystapamäärittely
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: spécification de représentation
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -224,7 +224,7 @@ data:
   - type: expression
     designation: Darstellungsspezifikation
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -260,7 +260,7 @@ data:
   - type: expression
     designation: 묘화 사양
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -333,7 +333,7 @@ data:
   - type: expression
     designation: спецификация графического отображения
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19117:2012
@@ -370,7 +370,7 @@ data:
   - type: expression
     designation: especificación de representación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -407,7 +407,7 @@ data:
   - type: expression
     designation: visualiseringsspecifikation
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012

--- a/geolexica-v2/21802bad-42a5-5e54-a396-12dc7cd9a000.yaml
+++ b/geolexica-v2/21802bad-42a5-5e54-a396-12dc7cd9a000.yaml
@@ -163,7 +163,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '300'
   notes:

--- a/geolexica-v2/21e32dca-49d7-5d07-aed4-03d50ac23697.yaml
+++ b/geolexica-v2/21e32dca-49d7-5d07-aed4-03d50ac23697.yaml
@@ -238,7 +238,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '243'
   notes:

--- a/geolexica-v2/22040e8f-21da-5ece-bd39-d03edf2a158c.yaml
+++ b/geolexica-v2/22040e8f-21da-5ece-bd39-d03edf2a158c.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '795'
   notes:

--- a/geolexica-v2/228127f4-449e-521d-8254-b75aa8ba37a3.yaml
+++ b/geolexica-v2/228127f4-449e-521d-8254-b75aa8ba37a3.yaml
@@ -45,7 +45,7 @@ data:
   - type: expression
     designation: universal face
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: واجهة عامة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -109,7 +109,7 @@ data:
   - type: expression
     designation: 宇宙面
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -143,7 +143,7 @@ data:
   - type: expression
     designation: rajaton tahko
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -172,7 +172,7 @@ data:
   - type: expression
     designation: face universelle
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -202,7 +202,7 @@ data:
   - type: expression
     designation: 全域フェイス
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -234,7 +234,7 @@ data:
   - type: expression
     designation: 무한 면
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -303,7 +303,7 @@ data:
   - type: expression
     designation: универсальная грань
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -338,7 +338,7 @@ data:
   - type: expression
     designation: cara universal
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -374,7 +374,7 @@ data:
   - type: expression
     designation: oavgränsat område
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/2366a3e9-618b-59de-845c-ce7be4649c1c.yaml
+++ b/geolexica-v2/2366a3e9-618b-59de-845c-ce7be4649c1c.yaml
@@ -158,7 +158,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '279'
   notes: []

--- a/geolexica-v2/23ae0d74-6ddc-5e05-a9b9-4cac3b688149.yaml
+++ b/geolexica-v2/23ae0d74-6ddc-5e05-a9b9-4cac3b688149.yaml
@@ -85,7 +85,6 @@ data:
     type: accepted
   - date: '2021-05-26T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: A "traffic flow" operation might return the number of persons or vehicles
       expected to move on or through some kind of transportation feature during a

--- a/geolexica-v2/23c3d03a-6d3f-5fa6-bb58-e67506383c62.yaml
+++ b/geolexica-v2/23c3d03a-6d3f-5fa6-bb58-e67506383c62.yaml
@@ -238,7 +238,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '153'
   notes: []

--- a/geolexica-v2/24dd4df8-0867-59ad-8951-e756749a4e0e.yaml
+++ b/geolexica-v2/24dd4df8-0867-59ad-8951-e756749a4e0e.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: feature table
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: جدول المعالم
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -99,7 +99,7 @@ data:
   - type: expression
     designation: 要素表
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -129,7 +129,7 @@ data:
   - type: expression
     designation: featuretabel
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -158,7 +158,7 @@ data:
   - type: expression
     designation: kohdetaulukko
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: table d'entités
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -202,7 +202,6 @@ data:
     type: accepted
   - date: '2018-11-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '182'
   notes: []
@@ -216,7 +215,7 @@ data:
   - type: expression
     designation: Feature-Tabelle
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -247,7 +246,7 @@ data:
   - type: expression
     designation: 피처 테이블
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -306,7 +305,7 @@ data:
   - type: expression
     designation: таблица пространственных  объектов
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -336,7 +335,7 @@ data:
   - type: expression
     designation: tabla de objetos geográficos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898
@@ -366,7 +365,7 @@ data:
   - type: expression
     designation: objekttabell
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-05-28T00:00:00+05:00'
   review_decision_date: '2018-11-15T00:00:00+05:00'
   review_decision_event: 46th Plneary of ISO/TC 211; Resolution 898

--- a/geolexica-v2/258dbb4f-9544-595e-b337-b29e1ff3a510.yaml
+++ b/geolexica-v2/258dbb4f-9544-595e-b337-b29e1ff3a510.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: rights holder
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: 권리자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -118,7 +118,7 @@ data:
   - type: expression
     designation: правообладатель
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -157,7 +157,7 @@ data:
   - type: expression
     designation: propietario de los derechos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/2674d171-f1d0-5437-a045-d19b9a7c12c7.yaml
+++ b/geolexica-v2/2674d171-f1d0-5437-a045-d19b9a7c12c7.yaml
@@ -181,7 +181,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '369'
   notes:

--- a/geolexica-v2/26e9447e-1556-5d0d-ab3c-2b2b102c1565.yaml
+++ b/geolexica-v2/26e9447e-1556-5d0d-ab3c-2b2b102c1565.yaml
@@ -275,7 +275,6 @@ data:
   dates:
   - date: '2004-08-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '203'
   notes: []
@@ -342,7 +341,6 @@ data:
   dates:
   - date: '2004-08-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '203'
   notes: []

--- a/geolexica-v2/2714bf64-ecb0-596b-a9fa-320da3eb9382.yaml
+++ b/geolexica-v2/2714bf64-ecb0-596b-a9fa-320da3eb9382.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: strong substitutability
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -75,7 +75,7 @@ data:
   - type: expression
     designation: قوة الابدالية
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -105,7 +105,7 @@ data:
   - type: expression
     designation: 强可替换性
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -136,7 +136,7 @@ data:
   - type: expression
     designation: voimakas korvautuvuus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -167,7 +167,7 @@ data:
   - type: expression
     designation: capacité de substitution forte
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -197,7 +197,7 @@ data:
   - type: expression
     designation: 強代替性
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -228,7 +228,7 @@ data:
   - type: expression
     designation: 강한 대체성
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -293,7 +293,7 @@ data:
   - type: expression
     designation: строгая  заменяемость
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -326,7 +326,7 @@ data:
   - type: expression
     designation: intercambiabilidad fuerte
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -358,7 +358,7 @@ data:
   - type: expression
     designation: stark utbytbarhet
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/27248acb-8135-5e31-b937-6ae670d0e6ab.yaml
+++ b/geolexica-v2/27248acb-8135-5e31-b937-6ae670d0e6ab.yaml
@@ -219,7 +219,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '317'
   notes:

--- a/geolexica-v2/2739286d-55b2-57be-ab9c-fe3504799b85.yaml
+++ b/geolexica-v2/2739286d-55b2-57be-ab9c-fe3504799b85.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: GeoLicence resolution
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: 지오허가증 분쟁 해결
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: разрешение геолицензии
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: resolución de GeoLicencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/2769cff7-d9d5-502a-8e6b-70c0dd8be675.yaml
+++ b/geolexica-v2/2769cff7-d9d5-502a-8e6b-70c0dd8be675.yaml
@@ -91,7 +91,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '351'
   notes: []

--- a/geolexica-v2/277c8979-9e35-5e77-b573-3f77b7a857c4.yaml
+++ b/geolexica-v2/277c8979-9e35-5e77-b573-3f77b7a857c4.yaml
@@ -201,7 +201,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '223'
   notes: []

--- a/geolexica-v2/286674e6-64b3-5ac1-ad6d-e72c24952555.yaml
+++ b/geolexica-v2/286674e6-64b3-5ac1-ad6d-e72c24952555.yaml
@@ -100,7 +100,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '885'
   notes:

--- a/geolexica-v2/28773012-bb54-5eb4-94c1-22f55ac19804.yaml
+++ b/geolexica-v2/28773012-bb54-5eb4-94c1-22f55ac19804.yaml
@@ -75,7 +75,6 @@ data:
   dates:
   - date: '2014-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1458'
   notes: []

--- a/geolexica-v2/28867a04-adde-57e6-961a-c54be7a2624b.yaml
+++ b/geolexica-v2/28867a04-adde-57e6-961a-c54be7a2624b.yaml
@@ -153,7 +153,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '470'
   notes: []

--- a/geolexica-v2/29ef9e34-49a8-5f6a-b138-b54277b20bbd.yaml
+++ b/geolexica-v2/29ef9e34-49a8-5f6a-b138-b54277b20bbd.yaml
@@ -346,7 +346,7 @@ data:
     normative_status: preferred
     designation: ректифицированная сетка
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of ISO 19123-1:2023(E)

--- a/geolexica-v2/2b4b4df5-882c-5e05-9b44-b9e7565cfbdd.yaml
+++ b/geolexica-v2/2b4b4df5-882c-5e05-9b44-b9e7565cfbdd.yaml
@@ -165,7 +165,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '278'
   notes: []

--- a/geolexica-v2/2be32550-6a66-5475-8d8a-1cfc430685c1.yaml
+++ b/geolexica-v2/2be32550-6a66-5475-8d8a-1cfc430685c1.yaml
@@ -246,7 +246,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '143'
   notes:

--- a/geolexica-v2/2d0cefd0-2387-5db4-9437-fd9b6c8f35d1.yaml
+++ b/geolexica-v2/2d0cefd0-2387-5db4-9437-fd9b6c8f35d1.yaml
@@ -235,7 +235,6 @@ data:
   dates:
   - date: '2000-12-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '76'
   notes: []

--- a/geolexica-v2/2d842a1a-af91-54b9-aa37-27875a5ebfe8.yaml
+++ b/geolexica-v2/2d842a1a-af91-54b9-aa37-27875a5ebfe8.yaml
@@ -83,7 +83,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '356'
   notes:

--- a/geolexica-v2/2d84858b-954f-5e13-b59c-64ef1d263a2f.yaml
+++ b/geolexica-v2/2d84858b-954f-5e13-b59c-64ef1d263a2f.yaml
@@ -239,7 +239,6 @@ data:
     type: accepted
   - date: '2015-07-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '81'
   notes:

--- a/geolexica-v2/2e4b1a39-311c-5060-9f88-3deac0258188.yaml
+++ b/geolexica-v2/2e4b1a39-311c-5060-9f88-3deac0258188.yaml
@@ -93,7 +93,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '868'
   notes: []
@@ -164,7 +163,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '868'
   notes: []

--- a/geolexica-v2/2f0e68e7-2e90-5448-9444-2e0862a25f02.yaml
+++ b/geolexica-v2/2f0e68e7-2e90-5448-9444-2e0862a25f02.yaml
@@ -216,7 +216,6 @@ data:
     type: accepted
   - date: '2014-07-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '350'
   notes:

--- a/geolexica-v2/2f2411f1-80ae-541c-8c2a-4943ffead41e.yaml
+++ b/geolexica-v2/2f2411f1-80ae-541c-8c2a-4943ffead41e.yaml
@@ -97,7 +97,6 @@ data:
   dates:
   - date: '2009-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: '"Deciduous needle leaf" is a nominal value that identifies a vegetation
       type.'

--- a/geolexica-v2/2f40357e-422f-5013-b392-1becc2be725f.yaml
+++ b/geolexica-v2/2f40357e-422f-5013-b392-1becc2be725f.yaml
@@ -69,7 +69,6 @@ data:
   dates:
   - date: '2009-04-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '188'
   notes: []

--- a/geolexica-v2/2f7cdc51-8f6a-58cc-ad0f-9009f4b0a22c.yaml
+++ b/geolexica-v2/2f7cdc51-8f6a-58cc-ad0f-9009f4b0a22c.yaml
@@ -206,7 +206,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: An odometer used in conjunction with predefined mile or kilometre origin
       points along a route and provides a linear reference to a position.

--- a/geolexica-v2/2fb792f0-f528-5924-950f-2077ef591b7f.yaml
+++ b/geolexica-v2/2fb792f0-f528-5924-950f-2077ef591b7f.yaml
@@ -72,7 +72,6 @@ data:
   dates:
   - date: '2009-04-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '82'
   notes:

--- a/geolexica-v2/328b938d-7fa2-5593-97fd-9d0f238178e8.yaml
+++ b/geolexica-v2/328b938d-7fa2-5593-97fd-9d0f238178e8.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: directed topological object
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: كائن طوبولوجي موجه
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -100,7 +100,7 @@ data:
   - type: expression
     designation: 有向拓扑对象
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -130,7 +130,7 @@ data:
   - type: expression
     designation: retningsbestemt topologisk objekt
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: suunnattu topologinen objekti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: objet topologique orienté
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -204,7 +204,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '140'
   notes: []
@@ -218,7 +217,7 @@ data:
   - type: expression
     designation: gerichtetes topologisches Objekt
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -247,7 +246,7 @@ data:
   - type: expression
     designation: 有向位相オブジェクト
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -276,7 +275,7 @@ data:
   - type: expression
     designation: 방향성 위상 객체
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -335,7 +334,7 @@ data:
   - type: expression
     designation: ориентированный топологический объект
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -365,7 +364,7 @@ data:
   - type: expression
     designation: objeto topológico orientado
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -395,7 +394,7 @@ data:
   - type: expression
     designation: orienterat topologiskt objekt
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/3298647a-edad-5425-91b8-fd70e9f083cc.yaml
+++ b/geolexica-v2/3298647a-edad-5425-91b8-fd70e9f083cc.yaml
@@ -209,7 +209,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '250'
   notes:

--- a/geolexica-v2/33ce1b50-2426-5956-a5b6-47c5c90f3ea8.yaml
+++ b/geolexica-v2/33ce1b50-2426-5956-a5b6-47c5c90f3ea8.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: licence manager
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 허가증 매니저
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -113,7 +113,7 @@ data:
   - type: expression
     designation: менеджер лицензий
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -150,7 +150,7 @@ data:
   - type: expression
     designation: gestor de licencias
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/35e8db91-eb5d-5833-8494-a6df1d3e7295.yaml
+++ b/geolexica-v2/35e8db91-eb5d-5833-8494-a6df1d3e7295.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: observation procedure
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -72,7 +72,7 @@ data:
   - type: expression
     designation: 관측절차
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -106,7 +106,7 @@ data:
   - type: expression
     designation: prosedur cerapan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -140,7 +140,7 @@ data:
   - type: expression
     designation: процедура наблюдения
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -174,7 +174,7 @@ data:
   - type: expression
     designation: procedimiento de observación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -208,7 +208,7 @@ data:
   - type: expression
     designation: bestämningsförfarande
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)

--- a/geolexica-v2/365371f5-5ed5-5d78-8723-f86705e27c4c.yaml
+++ b/geolexica-v2/365371f5-5ed5-5d78-8723-f86705e27c4c.yaml
@@ -302,7 +302,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '371'
   notes: []

--- a/geolexica-v2/368801e2-fe71-575b-a4c1-a810c9d59e92.yaml
+++ b/geolexica-v2/368801e2-fe71-575b-a4c1-a810c9d59e92.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '866'
   notes:

--- a/geolexica-v2/36af97dd-c85c-5d63-a5a1-eb2a1a2038cd.yaml
+++ b/geolexica-v2/36af97dd-c85c-5d63-a5a1-eb2a1a2038cd.yaml
@@ -126,7 +126,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '131'
   notes: []

--- a/geolexica-v2/36be045c-71d2-5f68-902e-11118f005980.yaml
+++ b/geolexica-v2/36be045c-71d2-5f68-902e-11118f005980.yaml
@@ -98,7 +98,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '909'
   notes:

--- a/geolexica-v2/36c836b6-0919-536c-aac5-321e228ab432.yaml
+++ b/geolexica-v2/36c836b6-0919-536c-aac5-321e228ab432.yaml
@@ -215,7 +215,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '141'
   notes:

--- a/geolexica-v2/374538a8-28a8-5312-9154-d5059ce346af.yaml
+++ b/geolexica-v2/374538a8-28a8-5312-9154-d5059ce346af.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '883'
   notes: []

--- a/geolexica-v2/38443fdf-5bed-5ef0-b177-0456e465f94e.yaml
+++ b/geolexica-v2/38443fdf-5bed-5ef0-b177-0456e465f94e.yaml
@@ -268,7 +268,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '20'
   notes:

--- a/geolexica-v2/38a50654-9cd3-55cd-8b4e-ddbe3041de7b.yaml
+++ b/geolexica-v2/38a50654-9cd3-55cd-8b4e-ddbe3041de7b.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: GeoLicence
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: 지오허가증
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: геолицензия
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: GeoLicencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/39646a3d-d077-5b5f-8e11-9f6d86afc724.yaml
+++ b/geolexica-v2/39646a3d-d077-5b5f-8e11-9f6d86afc724.yaml
@@ -70,7 +70,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '642'
   notes: []

--- a/geolexica-v2/3adf7ea8-c195-5994-b7af-be0d890fd875.yaml
+++ b/geolexica-v2/3adf7ea8-c195-5994-b7af-be0d890fd875.yaml
@@ -159,7 +159,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '366'
   notes:

--- a/geolexica-v2/3b1d60a9-1f93-50cd-ba9f-903e112aa024.yaml
+++ b/geolexica-v2/3b1d60a9-1f93-50cd-ba9f-903e112aa024.yaml
@@ -329,7 +329,7 @@ data:
   - type: expression
     designation: линейная система позиционирования
   language_code: rus
-  entry_status: замененный
+  entry_status: superseded
   review_date: '2009-02-02T00:00:00+05:00'
   review_decision_date: '2012-02-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19148:2012

--- a/geolexica-v2/3ba30411-d0da-51be-9468-769cdaae9cf8.yaml
+++ b/geolexica-v2/3ba30411-d0da-51be-9468-769cdaae9cf8.yaml
@@ -243,7 +243,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '206'
   notes: []

--- a/geolexica-v2/3cd92488-d748-552e-ab16-40aea50b184a.yaml
+++ b/geolexica-v2/3cd92488-d748-552e-ab16-40aea50b184a.yaml
@@ -219,7 +219,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '216'
   notes:

--- a/geolexica-v2/3d693adb-2300-58b5-9b53-2e9abf1eab66.yaml
+++ b/geolexica-v2/3d693adb-2300-58b5-9b53-2e9abf1eab66.yaml
@@ -250,7 +250,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '192'
   notes:

--- a/geolexica-v2/3dc80b28-c413-5569-8180-0da2cdc7035e.yaml
+++ b/geolexica-v2/3dc80b28-c413-5569-8180-0da2cdc7035e.yaml
@@ -74,7 +74,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '861'
   notes:

--- a/geolexica-v2/3e28193b-52c5-5301-9ebd-00a15de41416.yaml
+++ b/geolexica-v2/3e28193b-52c5-5301-9ebd-00a15de41416.yaml
@@ -208,7 +208,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '96'
   notes: []

--- a/geolexica-v2/3e513f17-f329-59ff-bd9d-2bdc28c94a8e.yaml
+++ b/geolexica-v2/3e513f17-f329-59ff-bd9d-2bdc28c94a8e.yaml
@@ -99,7 +99,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '887'
   notes:

--- a/geolexica-v2/3e52ddc3-9c6a-5a26-9c16-4a81b18bb5b9.yaml
+++ b/geolexica-v2/3e52ddc3-9c6a-5a26-9c16-4a81b18bb5b9.yaml
@@ -238,7 +238,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '755'
   notes: []

--- a/geolexica-v2/3eaf054b-fe3a-5dea-bd87-eef903d78642.yaml
+++ b/geolexica-v2/3eaf054b-fe3a-5dea-bd87-eef903d78642.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: agency
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: 대리기관
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -104,7 +104,7 @@ data:
   - type: expression
     designation: Agensi
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -138,7 +138,7 @@ data:
   - type: expression
     designation: агентирование
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -172,7 +172,7 @@ data:
   - type: expression
     designation: representación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/3f8792fb-322d-52f3-8b8e-8cd52b3f10f2.yaml
+++ b/geolexica-v2/3f8792fb-322d-52f3-8b8e-8cd52b3f10f2.yaml
@@ -172,7 +172,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '745'
   notes:

--- a/geolexica-v2/3fd263d3-f833-5a15-a8df-aed6057fc576.yaml
+++ b/geolexica-v2/3fd263d3-f833-5a15-a8df-aed6057fc576.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: licensor
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -78,7 +78,7 @@ data:
   - type: expression
     designation: 허가자, 검열관, 인가자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -115,7 +115,7 @@ data:
   - type: expression
     designation: pemberi lesen
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: лицензиар
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: entidad adjudicataria
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/403e4789-f53b-53bb-9847-6500b65a2ff0.yaml
+++ b/geolexica-v2/403e4789-f53b-53bb-9847-6500b65a2ff0.yaml
@@ -172,7 +172,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '281'
   notes:

--- a/geolexica-v2/40c01054-3718-5495-a010-92a5d9c872b1.yaml
+++ b/geolexica-v2/40c01054-3718-5495-a010-92a5d9c872b1.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: fail verdict
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -73,7 +73,7 @@ data:
   - type: expression
     designation: الحكم بالفشل
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -103,7 +103,7 @@ data:
   - type: expression
     designation: 失败判定
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: overensstemmelse, manglende
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -167,7 +167,7 @@ data:
   - type: expression
     designation: hylkäys
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -196,7 +196,7 @@ data:
   - type: expression
     designation: verdict d'échec
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -210,7 +210,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '166'
   notes:
@@ -226,7 +225,7 @@ data:
   - type: expression
     designation: Fehlernachweis
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -256,7 +255,7 @@ data:
   - type: expression
     designation: 不合格判定
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -286,7 +285,7 @@ data:
   - type: expression
     designation: 실패 판정
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -317,7 +316,7 @@ data:
   - type: expression
     designation: заключение о несоответствии
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -349,7 +348,7 @@ data:
   - type: expression
     designation: veredicto de fallo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -381,7 +380,7 @@ data:
   - type: expression
     designation: underkänt resultat
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/40d803dd-8cf3-50ac-be27-05834cf6b07b.yaml
+++ b/geolexica-v2/40d803dd-8cf3-50ac-be27-05834cf6b07b.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '890'
   notes: []

--- a/geolexica-v2/4175e994-7a97-558a-900c-e67c4f766008.yaml
+++ b/geolexica-v2/4175e994-7a97-558a-900c-e67c4f766008.yaml
@@ -79,7 +79,6 @@ data:
   dates:
   - date: '2009-04-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1118'
   notes:

--- a/geolexica-v2/41cef172-caaf-5ef5-8d60-2f91d51fb039.yaml
+++ b/geolexica-v2/41cef172-caaf-5ef5-8d60-2f91d51fb039.yaml
@@ -93,7 +93,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '558'
   notes:

--- a/geolexica-v2/41e795b4-8690-519a-ac42-e08599dfac1c.yaml
+++ b/geolexica-v2/41e795b4-8690-519a-ac42-e08599dfac1c.yaml
@@ -349,7 +349,6 @@ data:
     type: accepted
   - date: '2019-01-31T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '149'
   notes:

--- a/geolexica-v2/42f7b1c5-7a40-5ae5-b72f-4f6c2957e46a.yaml
+++ b/geolexica-v2/42f7b1c5-7a40-5ae5-b72f-4f6c2957e46a.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '315'
   notes: []

--- a/geolexica-v2/432f2eeb-e49f-5541-8bb4-30c556a3fa3f.yaml
+++ b/geolexica-v2/432f2eeb-e49f-5541-8bb4-30c556a3fa3f.yaml
@@ -197,7 +197,6 @@ data:
   dates:
   - date: '2005-08-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '340'
   notes: []

--- a/geolexica-v2/43c1e09c-8a9c-51cf-93d5-61f8e4fe16fa.yaml
+++ b/geolexica-v2/43c1e09c-8a9c-51cf-93d5-61f8e4fe16fa.yaml
@@ -92,7 +92,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '880'
   notes:

--- a/geolexica-v2/446fe704-e742-5a0d-a058-68d0c703cfb4.yaml
+++ b/geolexica-v2/446fe704-e742-5a0d-a058-68d0c703cfb4.yaml
@@ -206,7 +206,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '161'
   notes:

--- a/geolexica-v2/4506a424-7f1d-5fbb-8da9-40ae27d2bba1.yaml
+++ b/geolexica-v2/4506a424-7f1d-5fbb-8da9-40ae27d2bba1.yaml
@@ -223,7 +223,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '660'
   notes:
@@ -303,7 +302,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '660'
   notes:

--- a/geolexica-v2/4576c27d-3f95-57aa-a4aa-f6b1b5475795.yaml
+++ b/geolexica-v2/4576c27d-3f95-57aa-a4aa-f6b1b5475795.yaml
@@ -165,7 +165,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '662'
   notes:

--- a/geolexica-v2/4593c6d5-57ce-5938-b977-9be3a59cfabd.yaml
+++ b/geolexica-v2/4593c6d5-57ce-5938-b977-9be3a59cfabd.yaml
@@ -89,7 +89,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '560'
   notes: []

--- a/geolexica-v2/460e8e68-b14d-5594-a93e-03a13cbbbb93.yaml
+++ b/geolexica-v2/460e8e68-b14d-5594-a93e-03a13cbbbb93.yaml
@@ -46,7 +46,7 @@ data:
   - type: expression
     designation: acceptance testing <user>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: اختبار القبول (المستخدم)
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -111,7 +111,7 @@ data:
   - type: expression
     designation: 验收测试<用户>
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -145,7 +145,7 @@ data:
   - type: expression
     designation: acceptance test (bruger)
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -179,7 +179,7 @@ data:
   - type: expression
     designation: hyväksymistestaus (käyttäjän)
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -209,7 +209,7 @@ data:
   - type: expression
     designation: test d'acceptation (utilisateur)
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -223,7 +223,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '7'
   notes:
@@ -241,7 +240,7 @@ data:
   - type: expression
     designation: Akzeptanzprüfung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -272,7 +271,7 @@ data:
   - type: expression
     designation: 受入試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -304,7 +303,7 @@ data:
   - type: expression
     designation: 검수 시험<사용자>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -318,7 +317,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '7'
   notes:
@@ -336,7 +334,7 @@ data:
   - type: expression
     designation: ujian penerimaan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -370,7 +368,7 @@ data:
   - type: expression
     designation: тестирование на приемлемость для пользователя
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -404,7 +402,7 @@ data:
   - type: expression
     designation: prueba de aceptación (usuario)
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -438,7 +436,7 @@ data:
   - type: expression
     designation: acceptanstestning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/46103c42-2274-557c-bba2-6712bb9b0e6e.yaml
+++ b/geolexica-v2/46103c42-2274-557c-bba2-6712bb9b0e6e.yaml
@@ -175,7 +175,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '316'
   notes: []

--- a/geolexica-v2/4720047b-d2cb-5606-b542-287ed84c260f.yaml
+++ b/geolexica-v2/4720047b-d2cb-5606-b542-287ed84c260f.yaml
@@ -206,7 +206,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '349'
   notes:

--- a/geolexica-v2/473dd941-2f6d-5030-a0f1-e40d14b1a1cc.yaml
+++ b/geolexica-v2/473dd941-2f6d-5030-a0f1-e40d14b1a1cc.yaml
@@ -183,7 +183,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '32'
   notes: []

--- a/geolexica-v2/47421c6a-1668-59d5-a85c-0b4c51d84ddb.yaml
+++ b/geolexica-v2/47421c6a-1668-59d5-a85c-0b4c51d84ddb.yaml
@@ -190,7 +190,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '34'
   notes:

--- a/geolexica-v2/47f1642a-6580-574c-bea0-f41b605dc076.yaml
+++ b/geolexica-v2/47f1642a-6580-574c-bea0-f41b605dc076.yaml
@@ -85,7 +85,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '794'
   notes: []

--- a/geolexica-v2/4933c6d3-2972-529c-9654-ff3af55a78c2.yaml
+++ b/geolexica-v2/4933c6d3-2972-529c-9654-ff3af55a78c2.yaml
@@ -175,7 +175,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '280'
   notes:

--- a/geolexica-v2/4933dfe2-7f75-531d-b5ba-3f51cbc363bf.yaml
+++ b/geolexica-v2/4933dfe2-7f75-531d-b5ba-3f51cbc363bf.yaml
@@ -244,7 +244,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '242'
   notes: []

--- a/geolexica-v2/4a36aee3-6141-5955-abe4-8db8d406552e.yaml
+++ b/geolexica-v2/4a36aee3-6141-5955-abe4-8db8d406552e.yaml
@@ -85,7 +85,6 @@ data:
     type: accepted
   - date: '2021-05-26T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: A "height" feature attribute concept describes length in the vertical
       direction as a characteristic that may be shared by real world phenomena such

--- a/geolexica-v2/4ad3acf3-eaab-5de6-adb8-e50a96224964.yaml
+++ b/geolexica-v2/4ad3acf3-eaab-5de6-adb8-e50a96224964.yaml
@@ -37,7 +37,7 @@ data:
   - type: expression
     designation: agent
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: 대리인
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -105,7 +105,7 @@ data:
   - type: expression
     designation: Agen
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -138,7 +138,7 @@ data:
   - type: expression
     designation: агент
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -171,7 +171,7 @@ data:
   - type: expression
     designation: representante
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/4be3a737-202b-5c4d-aadf-a8bc08a57135.yaml
+++ b/geolexica-v2/4be3a737-202b-5c4d-aadf-a8bc08a57135.yaml
@@ -199,7 +199,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '100'
   notes: []

--- a/geolexica-v2/4c302e35-0867-508e-932a-3069ee6b2601.yaml
+++ b/geolexica-v2/4c302e35-0867-508e-932a-3069ee6b2601.yaml
@@ -158,7 +158,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '670'
   notes: []

--- a/geolexica-v2/4c9b71e1-8070-5665-bf31-2cc217901554.yaml
+++ b/geolexica-v2/4c9b71e1-8070-5665-bf31-2cc217901554.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: sublicensee
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: 2차 허가증 인가자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: Сублицензиат
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: sublicenciatario
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/4ea37288-b446-5ace-91ac-aa9058b6318b.yaml
+++ b/geolexica-v2/4ea37288-b446-5ace-91ac-aa9058b6318b.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: sampling feature
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -77,7 +77,7 @@ data:
   - type: expression
     designation: 샘플링 지형지물
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -114,7 +114,7 @@ data:
   - type: expression
     designation: образец выборки
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -151,7 +151,7 @@ data:
   - type: expression
     designation: entidad de muestreo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: provtagningsobjekt
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)

--- a/geolexica-v2/4f6f66a6-f1c8-5b83-bc0f-57850bd161b8.yaml
+++ b/geolexica-v2/4f6f66a6-f1c8-5b83-bc0f-57850bd161b8.yaml
@@ -51,7 +51,7 @@ data:
   - type: expression
     designation: data quality value type
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -87,7 +87,7 @@ data:
   - type: expression
     designation: نوع قيمة جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -125,7 +125,7 @@ data:
   - type: expression
     designation: 数据质量值类型
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: datakvalitet, værditype for
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -200,7 +200,7 @@ data:
   - type: expression
     designation: laatuarvon tyyppi
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -236,7 +236,7 @@ data:
   - type: expression
     designation: type de valeur de qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -250,7 +250,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: '"boolean variable", "percentage", "ratio"'
   id: '120'
@@ -273,7 +272,7 @@ data:
   - type: expression
     designation: Wertetyp der Datenqualitätsangabe
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -311,7 +310,7 @@ data:
   - type: expression
     designation: データ品質評価値型
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -349,7 +348,7 @@ data:
   - type: expression
     designation: 데이터 품질 값 유형
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -426,7 +425,7 @@ data:
   - type: expression
     designation: тип значения качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -464,7 +463,7 @@ data:
   - type: expression
     designation: tipo de valor de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -503,7 +502,7 @@ data:
   - type: expression
     designation: datakvalitetsresultattyp
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/4f8ae687-1e6b-5edf-87d9-15d4f9412dab.yaml
+++ b/geolexica-v2/4f8ae687-1e6b-5edf-87d9-15d4f9412dab.yaml
@@ -196,7 +196,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '406'
   notes: []

--- a/geolexica-v2/4fcdff2d-48d0-5b97-954b-2c925e95946f.yaml
+++ b/geolexica-v2/4fcdff2d-48d0-5b97-954b-2c925e95946f.yaml
@@ -231,7 +231,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '228'
   notes:

--- a/geolexica-v2/4ffd4b49-c369-554c-9357-b56a1c7f019c.yaml
+++ b/geolexica-v2/4ffd4b49-c369-554c-9357-b56a1c7f019c.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: surface patch
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: قطعة أرض
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -100,7 +100,7 @@ data:
   - type: expression
     designation: 曲面片
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -131,7 +131,7 @@ data:
   - type: expression
     designation: pintasegmentti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: portion de surface
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -176,7 +176,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '438'
   notes: []
@@ -190,7 +189,7 @@ data:
   - type: expression
     designation: Teilfläche
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -219,7 +218,7 @@ data:
   - type: expression
     designation: 曲面分
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -248,7 +247,7 @@ data:
   - type: expression
     designation: 표면 조각
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -308,7 +307,7 @@ data:
   - type: expression
     designation: лоскут
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -339,7 +338,7 @@ data:
   - type: expression
     designation: parche superficial
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -369,7 +368,7 @@ data:
   - type: expression
     designation: ytsegment
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/512e9994-626b-573a-983c-5e5d64bd91f6.yaml
+++ b/geolexica-v2/512e9994-626b-573a-983c-5e5d64bd91f6.yaml
@@ -159,7 +159,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '663'
   notes:

--- a/geolexica-v2/513e0b52-d5f0-5fb5-9e13-a77501b561f0.yaml
+++ b/geolexica-v2/513e0b52-d5f0-5fb5-9e13-a77501b561f0.yaml
@@ -46,7 +46,7 @@ data:
   - type: expression
     designation: service interface
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: واجهة خدمة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 面向服务的架构
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: palvelurajapinta
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -189,7 +189,7 @@ data:
   - type: expression
     designation: interface de service
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -203,7 +203,6 @@ data:
     type: accepted
   - date: '2014-11-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '407'
   notes: []
@@ -224,7 +223,7 @@ data:
   - type: expression
     designation: 'Serviceinterface (Syn.: Diensteschnittstelle)'
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -260,7 +259,7 @@ data:
   - type: expression
     designation: 서비스 인터페이스
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -297,7 +296,7 @@ data:
   - type: expression
     designation: интерфейс сервиса
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19101-1:2014
@@ -334,7 +333,7 @@ data:
   - type: expression
     designation: interfaz de servicio
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014

--- a/geolexica-v2/5163711e-be33-539f-b31e-1319eaaaeb9e.yaml
+++ b/geolexica-v2/5163711e-be33-539f-b31e-1319eaaaeb9e.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: conforming implementation
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: تنفيذ مطابِق
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -98,7 +98,7 @@ data:
   - type: expression
     designation: 一致性实现
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -127,7 +127,7 @@ data:
   - type: expression
     designation: overensstemmende implementering
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -156,7 +156,7 @@ data:
   - type: expression
     designation: vaatimuksenmukainen toteutus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -185,7 +185,7 @@ data:
   - type: expression
     designation: implémentation conforme
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -199,7 +199,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '77'
   notes: []
@@ -213,7 +212,7 @@ data:
   - type: expression
     designation: konforme Implementierung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -242,7 +241,7 @@ data:
   - type: expression
     designation: 適合実装
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -271,7 +270,7 @@ data:
   - type: expression
     designation: 적합성 구현
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -300,7 +299,7 @@ data:
   - type: expression
     designation: корректная реализация
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -329,7 +328,7 @@ data:
   - type: expression
     designation: implementación conforme
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -358,7 +357,7 @@ data:
   - type: expression
     designation: överensstämmande implementering
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/5244c053-1fb4-5ab4-a5c8-d11d3ebbc66b.yaml
+++ b/geolexica-v2/5244c053-1fb4-5ab4-a5c8-d11d3ebbc66b.yaml
@@ -158,7 +158,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '263'
   notes: []

--- a/geolexica-v2/548889b8-5ae1-5618-9ac9-5158e84e10e7.yaml
+++ b/geolexica-v2/548889b8-5ae1-5618-9ac9-5158e84e10e7.yaml
@@ -363,7 +363,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '145'
   notes: []

--- a/geolexica-v2/54a34e02-12ca-559b-8240-ce96e7cb24e1.yaml
+++ b/geolexica-v2/54a34e02-12ca-559b-8240-ce96e7cb24e1.yaml
@@ -178,7 +178,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '364'
   notes:

--- a/geolexica-v2/55dfa11f-f3bd-5c6b-ac3d-18d2bc9bf7a0.yaml
+++ b/geolexica-v2/55dfa11f-f3bd-5c6b-ac3d-18d2bc9bf7a0.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: owner
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: 소유주
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -117,7 +117,7 @@ data:
   - type: expression
     designation: pemilik
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -156,7 +156,7 @@ data:
   - type: expression
     designation: владелец
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -194,7 +194,7 @@ data:
   - type: expression
     designation: propietario
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/58046e48-f87d-5e4d-bc4b-c236909147b3.yaml
+++ b/geolexica-v2/58046e48-f87d-5e4d-bc4b-c236909147b3.yaml
@@ -104,7 +104,6 @@ data:
   dates:
   - date: '2014-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1455'
   notes:

--- a/geolexica-v2/59095fbc-75b2-521b-a68c-bb1fc8035027.yaml
+++ b/geolexica-v2/59095fbc-75b2-521b-a68c-bb1fc8035027.yaml
@@ -210,7 +210,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '154'
   notes: []

--- a/geolexica-v2/595f81da-f4b1-58c4-ad15-77f11a650456.yaml
+++ b/geolexica-v2/595f81da-f4b1-58c4-ad15-77f11a650456.yaml
@@ -235,7 +235,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '130'
   notes: []

--- a/geolexica-v2/597cc4f8-0d90-5560-b308-b46ac5563132.yaml
+++ b/geolexica-v2/597cc4f8-0d90-5560-b308-b46ac5563132.yaml
@@ -119,7 +119,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '907'
   notes:

--- a/geolexica-v2/59a8a598-27f7-518c-9544-d6aa978b79f7.yaml
+++ b/geolexica-v2/59a8a598-27f7-518c-9544-d6aa978b79f7.yaml
@@ -192,7 +192,6 @@ data:
   dates:
   - date: '2007-04-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '839'
   notes: []

--- a/geolexica-v2/5a40e4c2-4f0e-5e9c-b95f-57bccd1e5201.yaml
+++ b/geolexica-v2/5a40e4c2-4f0e-5e9c-b95f-57bccd1e5201.yaml
@@ -185,7 +185,6 @@ data:
   dates:
   - date: '2003-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '422'
   notes: []

--- a/geolexica-v2/5bbd0aa3-d1a8-5423-ac3c-1c46ad4ad94f.yaml
+++ b/geolexica-v2/5bbd0aa3-d1a8-5423-ac3c-1c46ad4ad94f.yaml
@@ -168,7 +168,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '991'
   notes:

--- a/geolexica-v2/5c02c05d-c0b6-5f71-ac8d-00aeb5ca3719.yaml
+++ b/geolexica-v2/5c02c05d-c0b6-5f71-ac8d-00aeb5ca3719.yaml
@@ -219,7 +219,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '36'
   notes:

--- a/geolexica-v2/5c98c9d8-fac6-5961-8e28-315fc993ab76.yaml
+++ b/geolexica-v2/5c98c9d8-fac6-5961-8e28-315fc993ab76.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: infringement (of a licence)
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 허가증 침해
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -112,7 +112,7 @@ data:
   - type: expression
     designation: нарушение (лицензии)
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -149,7 +149,7 @@ data:
   - type: expression
     designation: vulneración (de una licencia)
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/5d918611-db16-5642-8b25-05cb108cbe4a.yaml
+++ b/geolexica-v2/5d918611-db16-5642-8b25-05cb108cbe4a.yaml
@@ -47,7 +47,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -83,7 +83,7 @@ data:
   - type: abbreviation
     designation: م ا ت ا
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -115,7 +115,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -150,7 +150,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -185,7 +185,7 @@ data:
   - type: expression
     designation: testilisätiedot
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -216,7 +216,7 @@ data:
   - type: expression
     designation: Information eXtra d'Implémention pour les Essais
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -251,7 +251,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -283,7 +283,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -316,7 +316,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -350,7 +350,7 @@ data:
   - type: expression
     designation: дополнительная информация о реализации для тестирования
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -384,7 +384,7 @@ data:
   - type: expression
     designation: información extra de la implementación para pruebas
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -419,7 +419,7 @@ data:
   - type: abbreviation
     designation: IXIT
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/5e436177-5be6-5a35-88d2-d43d83c267a2.yaml
+++ b/geolexica-v2/5e436177-5be6-5a35-88d2-d43d83c267a2.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: graph
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: رسم بياني
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -106,7 +106,7 @@ data:
   - type: expression
     designation: 图
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -137,7 +137,7 @@ data:
   - type: expression
     designation: graf
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -171,7 +171,7 @@ data:
   - type: expression
     designation: graafi
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -200,7 +200,7 @@ data:
   - type: expression
     designation: graphe
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -214,7 +214,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '756'
   notes:
@@ -230,7 +229,7 @@ data:
   - type: expression
     designation: Graph
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -260,7 +259,7 @@ data:
   - type: expression
     designation: グラフ
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -291,7 +290,7 @@ data:
   - type: expression
     designation: 그래프
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -322,7 +321,7 @@ data:
   - type: expression
     designation: graf
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -384,7 +383,7 @@ data:
   - type: expression
     designation: граф
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -416,7 +415,7 @@ data:
   - type: expression
     designation: grafo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -447,7 +446,7 @@ data:
   - type: expression
     designation: graf
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/5e76dca6-e61d-522f-a54f-b7e73b81f948.yaml
+++ b/geolexica-v2/5e76dca6-e61d-522f-a54f-b7e73b81f948.yaml
@@ -204,7 +204,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '75'
   notes: []

--- a/geolexica-v2/5e8cdca4-92b2-57ab-a8d7-1950d60a0221.yaml
+++ b/geolexica-v2/5e8cdca4-92b2-57ab-a8d7-1950d60a0221.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: method <UML>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -85,7 +85,7 @@ data:
   - type: expression
     designation: طريقة <UML>
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -123,7 +123,7 @@ data:
   - type: expression
     designation: 方法<UML>
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -163,7 +163,7 @@ data:
   - type: expression
     designation: menetelmä <UML>
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -200,7 +200,7 @@ data:
   - type: expression
     designation: méthode <UML>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -214,7 +214,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '295'
   notes:
@@ -237,7 +236,7 @@ data:
   - type: expression
     designation: Methode <UML>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -277,7 +276,7 @@ data:
   - type: expression
     designation: 메서드
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -347,7 +346,7 @@ data:
   - type: expression
     designation: método <UML>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -385,7 +384,7 @@ data:
   - type: expression
     designation: method <UML>
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015

--- a/geolexica-v2/5ef01c35-5fa0-5582-b11b-26aa98571d51.yaml
+++ b/geolexica-v2/5ef01c35-5fa0-5582-b11b-26aa98571d51.yaml
@@ -132,7 +132,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1278'
   notes:

--- a/geolexica-v2/5fd031f3-6dce-50b1-8ff5-f27ee748902d.yaml
+++ b/geolexica-v2/5fd031f3-6dce-50b1-8ff5-f27ee748902d.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: universal solid
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -72,7 +72,7 @@ data:
   - type: expression
     designation: مجسم عام
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: 宇宙体
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -133,7 +133,7 @@ data:
   - type: expression
     designation: rajaton kappale
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: solide universel
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -192,7 +192,7 @@ data:
   - type: expression
     designation: 全域位相立体
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -222,7 +222,7 @@ data:
   - type: expression
     designation: 무한 입방체
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -283,7 +283,7 @@ data:
   - type: expression
     designation: универсальное тело
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -314,7 +314,7 @@ data:
   - type: expression
     designation: sólido universal
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -345,7 +345,7 @@ data:
   - type: expression
     designation: universal solid
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/60aae8ec-282e-5f58-af63-e0e94cd70918.yaml
+++ b/geolexica-v2/60aae8ec-282e-5f58-af63-e0e94cd70918.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: observation protocol
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: 관측 프로토콜
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -105,7 +105,7 @@ data:
   - type: expression
     designation: протокол наблюдения
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -139,7 +139,7 @@ data:
   - type: expression
     designation: protocolo de observación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)
@@ -172,7 +172,7 @@ data:
   - type: expression
     designation: bestämningsprotokoll
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-27T00:00:00+05:00'
   review_decision_date: '2023-04-27T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19156:2023(E)

--- a/geolexica-v2/61cfb8f5-47e6-5960-9f36-d3ae1ed1d284.yaml
+++ b/geolexica-v2/61cfb8f5-47e6-5960-9f36-d3ae1ed1d284.yaml
@@ -245,7 +245,6 @@ data:
     type: accepted
   - date: '2015-07-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '17'
   notes:

--- a/geolexica-v2/61f63cf7-3f64-5ab0-8b9a-2f28e6bffb5d.yaml
+++ b/geolexica-v2/61f63cf7-3f64-5ab0-8b9a-2f28e6bffb5d.yaml
@@ -336,7 +336,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: UML, EXPRESS, IDEF1X
   id: '70'

--- a/geolexica-v2/623a3dc1-67c7-5b7e-bfee-31a9de30e74b.yaml
+++ b/geolexica-v2/623a3dc1-67c7-5b7e-bfee-31a9de30e74b.yaml
@@ -245,7 +245,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '85'
   notes: []
@@ -316,7 +315,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '85'
   notes: []

--- a/geolexica-v2/6277ea1d-2ec7-5fe8-ab42-30a636845e5b.yaml
+++ b/geolexica-v2/6277ea1d-2ec7-5fe8-ab42-30a636845e5b.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: authorization
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: 인가
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -111,7 +111,7 @@ data:
   - type: expression
     designation: авторизация
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -148,7 +148,7 @@ data:
   - type: expression
     designation: autorización
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/62d3d9e7-1935-5365-961a-26d2a676f625.yaml
+++ b/geolexica-v2/62d3d9e7-1935-5365-961a-26d2a676f625.yaml
@@ -93,7 +93,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '889'
   notes:

--- a/geolexica-v2/6475357c-9ad2-5b1f-9634-add9144fdda5.yaml
+++ b/geolexica-v2/6475357c-9ad2-5b1f-9634-add9144fdda5.yaml
@@ -231,7 +231,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '241'
   notes: []

--- a/geolexica-v2/654baac6-d9e5-55a3-bec0-16018aeb1ba1.yaml
+++ b/geolexica-v2/654baac6-d9e5-55a3-bec0-16018aeb1ba1.yaml
@@ -219,7 +219,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '78'
   notes:
@@ -312,7 +311,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '78'
   notes:

--- a/geolexica-v2/6558d122-8725-570a-965f-9ea38584d34b.yaml
+++ b/geolexica-v2/6558d122-8725-570a-965f-9ea38584d34b.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2014-01-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1420'
   notes:

--- a/geolexica-v2/655b4dbc-807e-5749-83d2-ba60331021aa.yaml
+++ b/geolexica-v2/655b4dbc-807e-5749-83d2-ba60331021aa.yaml
@@ -292,7 +292,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '503'
   notes: []

--- a/geolexica-v2/65f41735-8878-557c-95f4-647dfb79e02c.yaml
+++ b/geolexica-v2/65f41735-8878-557c-95f4-647dfb79e02c.yaml
@@ -91,7 +91,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '888'
   notes: []

--- a/geolexica-v2/65fd8b2e-7177-51d8-b783-7b3dc429d36c.yaml
+++ b/geolexica-v2/65fd8b2e-7177-51d8-b783-7b3dc429d36c.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '572'
   notes: []

--- a/geolexica-v2/660985f5-2f6d-552a-b0e3-5d7a4d9c7143.yaml
+++ b/geolexica-v2/660985f5-2f6d-552a-b0e3-5d7a4d9c7143.yaml
@@ -297,7 +297,6 @@ data:
   dates:
   - date: '2007-09-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '148'
   notes:

--- a/geolexica-v2/668a393e-51db-57d7-bc58-5f9a17d65c68.yaml
+++ b/geolexica-v2/668a393e-51db-57d7-bc58-5f9a17d65c68.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: authentication
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 인증
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -113,7 +113,7 @@ data:
   - type: expression
     designation: аутентификация
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -150,7 +150,7 @@ data:
   - type: expression
     designation: autenticación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/6699f2f8-db2f-5799-9c8f-e741f46e27c4.yaml
+++ b/geolexica-v2/6699f2f8-db2f-5799-9c8f-e741f46e27c4.yaml
@@ -161,7 +161,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '265'
   notes:

--- a/geolexica-v2/66dc83ae-3297-5f25-b38d-d30ccb1cd0bd.yaml
+++ b/geolexica-v2/66dc83ae-3297-5f25-b38d-d30ccb1cd0bd.yaml
@@ -167,7 +167,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '269'
   notes:

--- a/geolexica-v2/67483256-60a7-5fc1-a746-c8f30656fc2f.yaml
+++ b/geolexica-v2/67483256-60a7-5fc1-a746-c8f30656fc2f.yaml
@@ -95,7 +95,6 @@ data:
   dates:
   - date: '2008-07-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: '079 572 5 degrees is represented as 50º04''46.461" sexagesimal degrees.'
   id: '905'
@@ -170,7 +169,6 @@ data:
   dates:
   - date: '2008-07-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: '079 572 5 degrees is represented as 50º04''46.461" sexagesimal degrees.'
   id: '905'

--- a/geolexica-v2/68557b9f-b786-52df-b1a8-d318663796e7.yaml
+++ b/geolexica-v2/68557b9f-b786-52df-b1a8-d318663796e7.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: GeoDRM extended (applied to resources)
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: GeoDRM 확장
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: расширение  GeoDRM   (применительно  к ресурсам)
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -136,7 +136,7 @@ data:
   - type: expression
     designation: GeoDRM extendido (aplicado a recursos)
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/68b45f9c-78bb-57ba-ad4b-3b397a6e5997.yaml
+++ b/geolexica-v2/68b45f9c-78bb-57ba-ad4b-3b397a6e5997.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: digital licence
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: 디지털 허가증
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -119,7 +119,7 @@ data:
   - type: expression
     designation: цифровая лицензия
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -159,7 +159,7 @@ data:
   - type: expression
     designation: licencia digital
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/68f93bfc-f182-526e-9cef-9dfcc475d09b.yaml
+++ b/geolexica-v2/68f93bfc-f182-526e-9cef-9dfcc475d09b.yaml
@@ -305,7 +305,7 @@ data:
   - type: expression
     designation: height
   language_code: rus
-  entry_status: замененный
+  entry_status: superseded
   review_date: '2007-12-07T00:00:00+05:00'
   review_decision_date: '2008-05-22T00:00:00+00:00'
   review_decision_event: результат FDIS голосования по  ISO 6709:2008

--- a/geolexica-v2/691e44dd-f97d-54b9-b2d8-e7c242956b49.yaml
+++ b/geolexica-v2/691e44dd-f97d-54b9-b2d8-e7c242956b49.yaml
@@ -163,7 +163,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '669'
   notes:

--- a/geolexica-v2/6b823306-711b-58ef-816e-420ea6494b7b.yaml
+++ b/geolexica-v2/6b823306-711b-58ef-816e-420ea6494b7b.yaml
@@ -225,7 +225,6 @@ data:
   dates:
   - date: '2002-08-16T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '39'
   notes: []

--- a/geolexica-v2/6c1c11ce-6c02-52e2-bb25-f8e729797b70.yaml
+++ b/geolexica-v2/6c1c11ce-6c02-52e2-bb25-f8e729797b70.yaml
@@ -87,7 +87,6 @@ data:
   dates:
   - date: '2012-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1434'
   notes:

--- a/geolexica-v2/6c58c5e2-bab3-51a0-ba19-8dcefbdeded2.yaml
+++ b/geolexica-v2/6c58c5e2-bab3-51a0-ba19-8dcefbdeded2.yaml
@@ -50,7 +50,7 @@ data:
   - type: expression
     designation: actor <UML>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -90,7 +90,7 @@ data:
   - type: expression
     designation: لغة "الممثل" UML
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -128,7 +128,7 @@ data:
   - type: expression
     designation: 参与者<UML>
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -168,7 +168,7 @@ data:
   - type: expression
     designation: aktør <UML>
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -206,7 +206,7 @@ data:
   - type: expression
     designation: toimija <UML>
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -244,7 +244,7 @@ data:
   - type: expression
     designation: acteur <UML>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -258,7 +258,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '9'
   notes:
@@ -282,7 +281,7 @@ data:
   - type: expression
     designation: Akteur <UML>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -320,7 +319,7 @@ data:
   - type: expression
     designation: 행위자 <UML>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -394,7 +393,7 @@ data:
   - type: expression
     designation: actor <UML>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -434,7 +433,7 @@ data:
   - type: expression
     designation: aktör <UML>
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015

--- a/geolexica-v2/6c9a3419-1520-56f3-87ab-ae35c193e93d.yaml
+++ b/geolexica-v2/6c9a3419-1520-56f3-87ab-ae35c193e93d.yaml
@@ -201,7 +201,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '335'
   notes: []

--- a/geolexica-v2/6d466b08-3141-5255-8c39-2550e6d94b72.yaml
+++ b/geolexica-v2/6d466b08-3141-5255-8c39-2550e6d94b72.yaml
@@ -85,7 +85,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '867'
   notes: []

--- a/geolexica-v2/6d4966c7-86a3-5e18-8da8-752448606466.yaml
+++ b/geolexica-v2/6d4966c7-86a3-5e18-8da8-752448606466.yaml
@@ -158,7 +158,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '307'
   notes: []

--- a/geolexica-v2/6e210d1f-e031-52f0-967a-3577ec8a9ee6.yaml
+++ b/geolexica-v2/6e210d1f-e031-52f0-967a-3577ec8a9ee6.yaml
@@ -128,7 +128,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '128'
   notes: []
@@ -199,7 +198,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '128'
   notes: []

--- a/geolexica-v2/6e90b8b2-7e1c-59fc-8573-ece345d9baff.yaml
+++ b/geolexica-v2/6e90b8b2-7e1c-59fc-8573-ece345d9baff.yaml
@@ -257,7 +257,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: XML, ISO 10303-21, ISO/IEC 8211.
   id: '152'

--- a/geolexica-v2/6f9c7db7-86a4-5c57-99a4-ababda0e4369.yaml
+++ b/geolexica-v2/6f9c7db7-86a4-5c57-99a4-ababda0e4369.yaml
@@ -76,7 +76,6 @@ data:
   dates:
   - date: '2014-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1475'
   notes: []

--- a/geolexica-v2/6fcd69a2-557e-529d-a6da-31bf67cd16b3.yaml
+++ b/geolexica-v2/6fcd69a2-557e-529d-a6da-31bf67cd16b3.yaml
@@ -88,7 +88,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '792'
   notes: []

--- a/geolexica-v2/6ff0bc31-42e3-5c18-81d0-4bbf21d0880d.yaml
+++ b/geolexica-v2/6ff0bc31-42e3-5c18-81d0-4bbf21d0880d.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: chain of agency
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: 대리인 사슬망
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -120,7 +120,7 @@ data:
   - type: expression
     designation: цепочка агентирования
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: cadena de representaciones
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/717e49b9-02b8-5e80-ae1a-fd82017de0fb.yaml
+++ b/geolexica-v2/717e49b9-02b8-5e80-ae1a-fd82017de0fb.yaml
@@ -67,7 +67,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '643'
   notes: []

--- a/geolexica-v2/720d5f4d-a31d-5d2e-918e-79156cad3290.yaml
+++ b/geolexica-v2/720d5f4d-a31d-5d2e-918e-79156cad3290.yaml
@@ -50,7 +50,7 @@ data:
   - type: expression
     designation: object <UML>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -90,7 +90,7 @@ data:
   - type: expression
     designation: كائن <UML>
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -127,7 +127,7 @@ data:
   - type: expression
     designation: 可观察类型
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -170,7 +170,7 @@ data:
   - type: expression
     designation: olio
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -208,7 +208,7 @@ data:
   - type: expression
     designation: objet <UML>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -222,7 +222,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '313'
   notes:
@@ -247,7 +246,7 @@ data:
   - type: expression
     designation: Objekt <UML>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -286,7 +285,7 @@ data:
   - type: expression
     designation: 객체 <UML>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -362,7 +361,7 @@ data:
   - type: expression
     designation: objeto <UML>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -402,7 +401,7 @@ data:
   - type: expression
     designation: objekt <UML>
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015

--- a/geolexica-v2/730ea1a3-3a03-5b07-ac50-083253587d01.yaml
+++ b/geolexica-v2/730ea1a3-3a03-5b07-ac50-083253587d01.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: transaction
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -77,7 +77,7 @@ data:
   - type: expression
     designation: 트랜잭션
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -114,7 +114,7 @@ data:
   - type: expression
     designation: transaksi
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -151,7 +151,7 @@ data:
   - type: expression
     designation: транзакция
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: transacción
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/745a0588-3b3d-5ee0-990d-56237e977192.yaml
+++ b/geolexica-v2/745a0588-3b3d-5ee0-990d-56237e977192.yaml
@@ -241,7 +241,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '87'
   notes:

--- a/geolexica-v2/74d12f4c-0562-562a-9442-4812145b5d1b.yaml
+++ b/geolexica-v2/74d12f4c-0562-562a-9442-4812145b5d1b.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: geometry value object
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: كائن ذو قيمة هندسية
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -98,7 +98,7 @@ data:
   - type: expression
     designation: 几何值对象
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -127,7 +127,7 @@ data:
   - type: expression
     designation: geometrisk værdiobjekt
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -156,7 +156,7 @@ data:
   - type: expression
     designation: geometria-arvo-objekti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -185,7 +185,7 @@ data:
   - type: expression
     designation: objet géométrie - valeur
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -199,7 +199,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '757'
   notes: []
@@ -213,7 +212,7 @@ data:
   - type: expression
     designation: geometrisches Werteobjekt
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -242,7 +241,7 @@ data:
   - type: expression
     designation: 기하 값 객체
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -299,7 +298,7 @@ data:
   - type: expression
     designation: объект «геометрия -значение»
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -328,7 +327,7 @@ data:
   - type: expression
     designation: objeto valor geométrico
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -358,7 +357,7 @@ data:
   - type: expression
     designation: geometri-värdeobjekt
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)

--- a/geolexica-v2/76398c15-b3b3-5cfa-ad4e-e06e697d9bd8.yaml
+++ b/geolexica-v2/76398c15-b3b3-5cfa-ad4e-e06e697d9bd8.yaml
@@ -227,7 +227,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '11'
   notes:

--- a/geolexica-v2/7694f400-52d5-5e0b-8bfa-e80856bb7f55.yaml
+++ b/geolexica-v2/7694f400-52d5-5e0b-8bfa-e80856bb7f55.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: non-conformance
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -68,7 +68,7 @@ data:
   - type: expression
     designation: عدم المطابقة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -97,7 +97,7 @@ data:
   - type: expression
     designation: 不一致
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -126,7 +126,7 @@ data:
   - type: expression
     designation: vaatimusten täyttymättä jääminen
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -155,7 +155,7 @@ data:
   - type: expression
     designation: non-conformité
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -169,7 +169,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '310'
   notes: []
@@ -183,7 +182,7 @@ data:
   - type: expression
     designation: Nichtkonformität
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -212,7 +211,7 @@ data:
   - type: expression
     designation: 不適合，不適合性
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -241,7 +240,7 @@ data:
   - type: expression
     designation: 부적합
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -270,7 +269,7 @@ data:
   - type: expression
     designation: несоответствие
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -299,7 +298,7 @@ data:
   - type: expression
     designation: no conformidad
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -328,7 +327,7 @@ data:
   - type: expression
     designation: överensstämmelseavvikelse
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/77f9bf06-8859-5fe5-b182-359dd7e3d2b6.yaml
+++ b/geolexica-v2/77f9bf06-8859-5fe5-b182-359dd7e3d2b6.yaml
@@ -193,7 +193,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: An instance of the feature type "land parcel" is replaced by two instances
       of the same type when the parcel is legally subdivided.

--- a/geolexica-v2/782b5f7e-e4fe-55d3-a72a-b8a1fbc91cfc.yaml
+++ b/geolexica-v2/782b5f7e-e4fe-55d3-a72a-b8a1fbc91cfc.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: geometry value pair
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: زوج ذو قيمة هندسية
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -100,7 +100,7 @@ data:
   - type: expression
     designation: 几何数值对
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -130,7 +130,7 @@ data:
   - type: expression
     designation: geometrisk værdipar
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: geometria-arvopari
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: paire géométrie - valeur
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -204,7 +204,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '758'
   notes: []
@@ -218,7 +217,7 @@ data:
   - type: expression
     designation: geometrisches Wertepaar
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -247,7 +246,7 @@ data:
   - type: expression
     designation: 기하 값 쌍
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -306,7 +305,7 @@ data:
   - type: expression
     designation: пара «геометрический элемент – значение»
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -336,7 +335,7 @@ data:
   - type: expression
     designation: par de valores geométricos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -367,7 +366,7 @@ data:
   - type: expression
     designation: geometri-värdepar
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)

--- a/geolexica-v2/78e82472-80af-522e-99e6-2927744e7eba.yaml
+++ b/geolexica-v2/78e82472-80af-522e-99e6-2927744e7eba.yaml
@@ -210,7 +210,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '97'
   notes:

--- a/geolexica-v2/798934c1-8893-5c0b-a403-0c3c98ec91e8.yaml
+++ b/geolexica-v2/798934c1-8893-5c0b-a403-0c3c98ec91e8.yaml
@@ -156,7 +156,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '498'
   notes: []

--- a/geolexica-v2/79cd25e5-d5d7-5fa2-be89-b552857ff673.yaml
+++ b/geolexica-v2/79cd25e5-d5d7-5fa2-be89-b552857ff673.yaml
@@ -182,7 +182,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '734'
   notes: []

--- a/geolexica-v2/79d8a10f-e833-5bfa-8698-68a48a2100c2.yaml
+++ b/geolexica-v2/79d8a10f-e833-5bfa-8698-68a48a2100c2.yaml
@@ -80,7 +80,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '816'
   notes:

--- a/geolexica-v2/7ac4bd01-5b86-5f0a-ad48-4b1af5b3ac41.yaml
+++ b/geolexica-v2/7ac4bd01-5b86-5f0a-ad48-4b1af5b3ac41.yaml
@@ -201,7 +201,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '360'
   notes: []

--- a/geolexica-v2/7b936d6a-20b9-5bb5-9e29-a6764e2c3548.yaml
+++ b/geolexica-v2/7b936d6a-20b9-5bb5-9e29-a6764e2c3548.yaml
@@ -159,7 +159,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '321'
   notes: []

--- a/geolexica-v2/7d38ff25-9260-5df8-90aa-acbb7cdba0c2.yaml
+++ b/geolexica-v2/7d38ff25-9260-5df8-90aa-acbb7cdba0c2.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: resource <GeoDRM>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -75,7 +75,7 @@ data:
   - type: expression
     designation: 자원
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -112,7 +112,7 @@ data:
   - type: expression
     designation: ресурс <GeoDRM>
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -145,7 +145,7 @@ data:
   - type: expression
     designation: recurso <GeoDRM>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/7ef5d79c-a8d8-5ce0-b82f-5bedef3d894e.yaml
+++ b/geolexica-v2/7ef5d79c-a8d8-5ce0-b82f-5bedef3d894e.yaml
@@ -207,7 +207,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '162'
   notes: []

--- a/geolexica-v2/7efcb703-2b28-5e52-ad7e-aed7939db82f.yaml
+++ b/geolexica-v2/7efcb703-2b28-5e52-ad7e-aed7939db82f.yaml
@@ -197,7 +197,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '444'
   notes: []

--- a/geolexica-v2/80451ccb-cb9c-5672-bd4c-9dcddea311af.yaml
+++ b/geolexica-v2/80451ccb-cb9c-5672-bd4c-9dcddea311af.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '789'
   notes: []

--- a/geolexica-v2/80a04e52-ac5c-5b44-b738-49c2bf2978d5.yaml
+++ b/geolexica-v2/80a04e52-ac5c-5b44-b738-49c2bf2978d5.yaml
@@ -208,7 +208,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: This may be motion of the position sensor mounted on a vehicle or other
       platform or motion of an object being tracked by a positioning system.

--- a/geolexica-v2/82665cf7-752c-56ff-bf8d-196aee1ece7f.yaml
+++ b/geolexica-v2/82665cf7-752c-56ff-bf8d-196aee1ece7f.yaml
@@ -49,7 +49,7 @@ data:
   - type: expression
     designation: data quality evaluation procedure
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -83,7 +83,7 @@ data:
   - type: expression
     designation: إجراءات تقييم جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -119,7 +119,7 @@ data:
   - type: expression
     designation: 数据质量评价过程
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -156,7 +156,7 @@ data:
   - type: expression
     designation: datakvalitet, procedure til vurdering af
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -192,7 +192,7 @@ data:
   - type: expression
     designation: tiedon laadun arviointi
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -229,7 +229,7 @@ data:
   - type: expression
     designation: procédure d'évaluation de la qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -243,7 +243,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '114'
   notes: []
@@ -264,7 +263,7 @@ data:
   - type: expression
     designation: Verfahren zur Datenqualitätsbestimmung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -300,7 +299,7 @@ data:
   - type: expression
     designation: データ品質評価手順
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -336,7 +335,7 @@ data:
   - type: expression
     designation: 데이터 품질 평가 절차
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -409,7 +408,7 @@ data:
   - type: expression
     designation: процедура оценки качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО19157:2013
@@ -446,7 +445,7 @@ data:
   - type: expression
     designation: procedimiento de evaluación de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/82bf7f4a-1598-5213-af58-b5cd733c802e.yaml
+++ b/geolexica-v2/82bf7f4a-1598-5213-af58-b5cd733c802e.yaml
@@ -156,7 +156,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '445'
   notes: []

--- a/geolexica-v2/82cda63e-6e31-59f2-beb3-7582308e00e1.yaml
+++ b/geolexica-v2/82cda63e-6e31-59f2-beb3-7582308e00e1.yaml
@@ -245,7 +245,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '147'
   notes:

--- a/geolexica-v2/8306c66d-77be-54c4-80c0-dd0fd2e3eab5.yaml
+++ b/geolexica-v2/8306c66d-77be-54c4-80c0-dd0fd2e3eab5.yaml
@@ -237,7 +237,6 @@ data:
     type: accepted
   - date: '2008-06-01T01:00:00+06:00'
     type: amended
-  definition: []
   examples: []
   id: '63'
   notes: []

--- a/geolexica-v2/83e2c658-b454-5f09-a256-7fdba35d9706.yaml
+++ b/geolexica-v2/83e2c658-b454-5f09-a256-7fdba35d9706.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: conformance assessment process
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: عملية تقييم المطابقة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -99,7 +99,7 @@ data:
   - type: expression
     designation: 一致性评价过程
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -129,7 +129,7 @@ data:
   - type: expression
     designation: overensstemmelse, proces til vurdering af
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -159,7 +159,7 @@ data:
   - type: expression
     designation: vaatimuksenmukaisuuden arviointi
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: processus d'évaluation de conformité
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -202,7 +202,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '72'
   notes: []
@@ -216,7 +215,7 @@ data:
   - type: expression
     designation: Konformitätsauswertungsprozess
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -245,7 +244,7 @@ data:
   - type: expression
     designation: 適合性評価過程
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -274,7 +273,7 @@ data:
   - type: expression
     designation: 적합성 평가 과정
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -304,7 +303,7 @@ data:
   - type: expression
     designation: процесс оценки соответствия
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -334,7 +333,7 @@ data:
   - type: expression
     designation: proceso de evaluación de la conformidad
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -364,7 +363,7 @@ data:
   - type: expression
     designation: process för överensstämmelsebedömning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/842deebc-dede-57c1-a0de-f90c97b02c72.yaml
+++ b/geolexica-v2/842deebc-dede-57c1-a0de-f90c97b02c72.yaml
@@ -222,7 +222,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '220'
   notes:

--- a/geolexica-v2/8491c93b-1cf3-5b09-887a-4dab97365252.yaml
+++ b/geolexica-v2/8491c93b-1cf3-5b09-887a-4dab97365252.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: falsification test
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: اختبار الاخطاء
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -106,7 +106,7 @@ data:
   - type: expression
     designation: 证伪测试
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -139,7 +139,7 @@ data:
   - type: expression
     designation: fejlfindingstest
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -172,7 +172,7 @@ data:
   - type: expression
     designation: kumoamistesti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -201,7 +201,7 @@ data:
   - type: expression
     designation: test de déverminage
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -215,7 +215,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '167'
   notes:
@@ -233,7 +232,7 @@ data:
   - type: expression
     designation: Fehlertest
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -263,7 +262,7 @@ data:
   - type: expression
     designation: 不具合試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -295,7 +294,7 @@ data:
   - type: expression
     designation: 오류 검증 시험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -327,7 +326,7 @@ data:
   - type: expression
     designation: тест на искажения
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -360,7 +359,7 @@ data:
   - type: expression
     designation: prueba de falsedad
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -393,7 +392,7 @@ data:
   - type: expression
     designation: felsökningstetst
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/85b82ca2-38a8-5e40-b9c4-1b31d6e4c5e1.yaml
+++ b/geolexica-v2/85b82ca2-38a8-5e40-b9c4-1b31d6e4c5e1.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '882'
   notes:

--- a/geolexica-v2/85e053e8-6be9-5d06-9c87-1b1c0601b05f.yaml
+++ b/geolexica-v2/85e053e8-6be9-5d06-9c87-1b1c0601b05f.yaml
@@ -258,7 +258,6 @@ data:
     type: accepted
   - date: '2015-07-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '725'
   notes:

--- a/geolexica-v2/86a076ad-e0db-513d-ba1a-44353e0791ce.yaml
+++ b/geolexica-v2/86a076ad-e0db-513d-ba1a-44353e0791ce.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: lease
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -75,7 +75,7 @@ data:
   - type: expression
     designation: 임대차 계약
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -111,7 +111,7 @@ data:
   - type: expression
     designation: pajakan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -147,7 +147,7 @@ data:
   - type: expression
     designation: аренда
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -183,7 +183,7 @@ data:
   - type: expression
     designation: arrendar
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/86cbfd2b-7e14-5886-8181-d2279418dd86.yaml
+++ b/geolexica-v2/86cbfd2b-7e14-5886-8181-d2279418dd86.yaml
@@ -203,7 +203,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '467'
   notes:

--- a/geolexica-v2/86eb31ae-2d11-5d5a-8536-accfd6f903cc.yaml
+++ b/geolexica-v2/86eb31ae-2d11-5d5a-8536-accfd6f903cc.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: right <GeoDRM>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -84,7 +84,7 @@ data:
   - type: expression
     designation: 권리
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -125,7 +125,7 @@ data:
   - type: expression
     designation: права <GeoDRM>
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -166,7 +166,7 @@ data:
   - type: expression
     designation: derechos <GeoDRM>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/881cd7ab-3fce-5790-87fa-a507ce92a38f.yaml
+++ b/geolexica-v2/881cd7ab-3fce-5790-87fa-a507ce92a38f.yaml
@@ -229,7 +229,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '505'
   notes: []

--- a/geolexica-v2/884a584b-10a9-52cc-8dd8-02338f951db2.yaml
+++ b/geolexica-v2/884a584b-10a9-52cc-8dd8-02338f951db2.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: fair use
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -82,7 +82,7 @@ data:
   - type: expression
     designation: 공정 사용
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -123,7 +123,7 @@ data:
   - type: expression
     designation: добросовестное использование
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -164,7 +164,7 @@ data:
   - type: expression
     designation: uso legítimo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/8893e3a6-7530-5ae0-9ddb-eede32218216.yaml
+++ b/geolexica-v2/8893e3a6-7530-5ae0-9ddb-eede32218216.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: metadata schema
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: مخطط توصيف بيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -118,7 +118,7 @@ data:
   - type: expression
     designation: 元数据模式
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -157,7 +157,7 @@ data:
   - type: expression
     designation: metatietomalli
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -193,7 +193,7 @@ data:
   - type: expression
     designation: schéma de métadonnées
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -207,7 +207,6 @@ data:
     type: accepted
   - date: '2014-11-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '292'
   notes:
@@ -229,7 +228,7 @@ data:
   - type: expression
     designation: Metadatenschema
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -266,7 +265,7 @@ data:
   - type: expression
     designation: 메타데이터 스키마
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -303,7 +302,7 @@ data:
   - type: expression
     designation: схема метаданных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19101-1:2014
@@ -340,7 +339,7 @@ data:
   - type: expression
     designation: esquema de metadatos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -378,7 +377,7 @@ data:
   - type: expression
     designation: metadataschema
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014

--- a/geolexica-v2/89143597-5843-5088-a96e-35286d39c393.yaml
+++ b/geolexica-v2/89143597-5843-5088-a96e-35286d39c393.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: testing laboratory
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -67,7 +67,7 @@ data:
   - type: expression
     designation: معمل اختبار
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -96,7 +96,7 @@ data:
   - type: expression
     designation: 测试实验室
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -125,7 +125,7 @@ data:
   - type: expression
     designation: testilaboratorio
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -154,7 +154,7 @@ data:
   - type: expression
     designation: laboratoire d'essais
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -183,7 +183,7 @@ data:
   - type: expression
     designation: 試験機関
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -212,7 +212,7 @@ data:
   - type: expression
     designation: 시험소
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -241,7 +241,7 @@ data:
   - type: expression
     designation: испытательная лаборатория
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -270,7 +270,7 @@ data:
   - type: expression
     designation: laboratorio de prueba
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -299,7 +299,7 @@ data:
   - type: expression
     designation: provningslaboratorium
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/89ae5ede-941f-50f7-9855-854912c9b346.yaml
+++ b/geolexica-v2/89ae5ede-941f-50f7-9855-854912c9b346.yaml
@@ -95,7 +95,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '901'
   notes: []

--- a/geolexica-v2/89e6bae7-0496-552a-93b1-e42d8116ead4.yaml
+++ b/geolexica-v2/89e6bae7-0496-552a-93b1-e42d8116ead4.yaml
@@ -214,7 +214,6 @@ data:
     type: accepted
   - date: '2019-02-14T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '193'
   notes:

--- a/geolexica-v2/89f6f744-555a-58ba-88bb-15a7368916e0.yaml
+++ b/geolexica-v2/89f6f744-555a-58ba-88bb-15a7368916e0.yaml
@@ -202,7 +202,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '468'
   notes:

--- a/geolexica-v2/8a4dbc1e-7e52-5cac-b358-1340a41189e5.yaml
+++ b/geolexica-v2/8a4dbc1e-7e52-5cac-b358-1340a41189e5.yaml
@@ -56,7 +56,7 @@ data:
   - type: expression
     designation: data quality scope
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -95,7 +95,7 @@ data:
   - type: expression
     designation: نطاق جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -132,7 +132,7 @@ data:
   - type: expression
     designation: 数据质量范围
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -173,7 +173,7 @@ data:
   - type: expression
     designation: datakvalitet, omfang af
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -216,7 +216,7 @@ data:
   - type: expression
     designation: laatukuvauksen laajuus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -253,7 +253,7 @@ data:
   - type: expression
     designation: domaine d'application des informations sur la qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -267,7 +267,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '118'
   notes:
@@ -294,7 +293,7 @@ data:
   - type: expression
     designation: Geltungsbereich der Datenqualitätsangabe
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -331,7 +330,7 @@ data:
   - type: expression
     designation: データ品質適用範囲
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -370,7 +369,7 @@ data:
   - type: expression
     designation: 데이터 품질 범위
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -455,7 +454,7 @@ data:
   - type: expression
     designation: область определения качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -499,7 +498,7 @@ data:
   - type: expression
     designation: ámbito de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -543,7 +542,7 @@ data:
   - type: expression
     designation: datakvalitetsdelomfattning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/8a824921-85b1-592c-84c6-7323ba43fd24.yaml
+++ b/geolexica-v2/8a824921-85b1-592c-84c6-7323ba43fd24.yaml
@@ -76,7 +76,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '645'
   notes:

--- a/geolexica-v2/8a8a23b6-b63a-5525-b983-46d35903bc96.yaml
+++ b/geolexica-v2/8a8a23b6-b63a-5525-b983-46d35903bc96.yaml
@@ -91,7 +91,6 @@ data:
     type: accepted
   - date: '2021-05-26T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: The feature concept "road" may be used to specify several different feature
       types, each with a different set of properties appropriate for a particular

--- a/geolexica-v2/8adeebd2-c370-5983-bdbe-4f15f0895972.yaml
+++ b/geolexica-v2/8adeebd2-c370-5983-bdbe-4f15f0895972.yaml
@@ -238,7 +238,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '727'
   notes:

--- a/geolexica-v2/8b030979-f2b8-511a-b84d-6ac76c7d5dd0.yaml
+++ b/geolexica-v2/8b030979-f2b8-511a-b84d-6ac76c7d5dd0.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: licence
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -82,7 +82,7 @@ data:
   - type: expression
     designation: 허가증
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -121,7 +121,7 @@ data:
   - type: expression
     designation: lesen
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: лицензия
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -199,7 +199,7 @@ data:
   - type: expression
     designation: licencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -237,7 +237,7 @@ data:
   - type: expression
     designation: licens
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/8b648b65-168d-59d2-bb3b-58f673c652a3.yaml
+++ b/geolexica-v2/8b648b65-168d-59d2-bb3b-58f673c652a3.yaml
@@ -58,7 +58,7 @@ data:
   - type: expression
     designation: data quality result
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -99,7 +99,7 @@ data:
   - type: expression
     designation: نتيجة جودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -136,7 +136,7 @@ data:
   - type: expression
     designation: 数据质量结果
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -182,7 +182,7 @@ data:
   - type: expression
     designation: datakvalitetsresultat
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -225,7 +225,7 @@ data:
   - type: expression
     designation: laatutulos
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -263,7 +263,7 @@ data:
   - type: expression
     designation: résultat de qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -277,7 +277,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: A data quality result of "90" with a data quality value type of "percentage"
       reported for the data quality element and its data quality subelement "completeness,
@@ -305,7 +304,7 @@ data:
   - type: expression
     designation: Datenqualitätsangabe
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -342,7 +341,7 @@ data:
   - type: expression
     designation: データ品質評価結果
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -381,7 +380,7 @@ data:
   - type: expression
     designation: 데이터 품질 결과
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -466,7 +465,7 @@ data:
   - type: expression
     designation: результат оценки качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -511,7 +510,7 @@ data:
   - type: expression
     designation: resultado de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -556,7 +555,7 @@ data:
   - type: expression
     designation: datakvalitetsreultat
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/8b810ca4-146c-5f64-9f1f-40cd112bf3ad.yaml
+++ b/geolexica-v2/8b810ca4-146c-5f64-9f1f-40cd112bf3ad.yaml
@@ -266,7 +266,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '137'
   notes:

--- a/geolexica-v2/8c3d6956-d147-5d47-8571-88f03e020598.yaml
+++ b/geolexica-v2/8c3d6956-d147-5d47-8571-88f03e020598.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '451'
   notes:

--- a/geolexica-v2/8cb77423-cf7b-5acb-b3f0-faa4d405232b.yaml
+++ b/geolexica-v2/8cb77423-cf7b-5acb-b3f0-faa4d405232b.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '266'
   notes: []

--- a/geolexica-v2/8dad4b0d-63bb-5715-b1f3-17bf26b995b1.yaml
+++ b/geolexica-v2/8dad4b0d-63bb-5715-b1f3-17bf26b995b1.yaml
@@ -201,7 +201,6 @@ data:
     type: accepted
   - date: '2023-08-23T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '840'
   notes:

--- a/geolexica-v2/8db5f5a1-5f16-5aed-bc94-48c4e248eb97.yaml
+++ b/geolexica-v2/8db5f5a1-5f16-5aed-bc94-48c4e248eb97.yaml
@@ -166,7 +166,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '256'
   notes:

--- a/geolexica-v2/8ebd948d-c4e4-54ff-9f7c-e85bd98a69e4.yaml
+++ b/geolexica-v2/8ebd948d-c4e4-54ff-9f7c-e85bd98a69e4.yaml
@@ -216,7 +216,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '6'
   notes:

--- a/geolexica-v2/921a3e04-6404-5ba8-b33f-e3aa2a64ffa7.yaml
+++ b/geolexica-v2/921a3e04-6404-5ba8-b33f-e3aa2a64ffa7.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: provenance
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: 기원, 출처, 유래
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -105,7 +105,7 @@ data:
   - type: expression
     designation: provenans
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -139,7 +139,7 @@ data:
   - type: expression
     designation: происхождение
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -174,7 +174,7 @@ data:
   - type: expression
     designation: procedencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/92663c3f-b142-5fbc-9720-cd19cc0f413b.yaml
+++ b/geolexica-v2/92663c3f-b142-5fbc-9720-cd19cc0f413b.yaml
@@ -54,7 +54,7 @@ data:
   - type: expression
     designation: external function
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -91,7 +91,7 @@ data:
   - type: expression
     designation: الوظيفة الخارجية
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -128,7 +128,7 @@ data:
   - type: expression
     designation: 外部函数
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -168,7 +168,7 @@ data:
   - type: expression
     designation: ekstern funktion
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -208,7 +208,7 @@ data:
   - type: expression
     designation: ulkoinen toiminto
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -244,7 +244,7 @@ data:
   - type: expression
     designation: fonction externe
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -285,7 +285,7 @@ data:
   - type: expression
     designation: externe Funktion
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -323,7 +323,7 @@ data:
   - type: expression
     designation: 외부 함수
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -337,7 +337,6 @@ data:
     type: accepted
   - date: '2012-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '164'
   notes:
@@ -363,7 +362,7 @@ data:
   - type: expression
     designation: fungsi luaran
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -444,7 +443,7 @@ data:
   - type: expression
     designation: внешняя функция
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19117:2012
@@ -485,7 +484,7 @@ data:
   - type: expression
     designation: función externa
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -527,7 +526,7 @@ data:
   - type: expression
     designation: extern funktion
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-12-15T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012

--- a/geolexica-v2/92d4fec8-30a1-558c-bcd7-5bea91b4916f.yaml
+++ b/geolexica-v2/92d4fec8-30a1-558c-bcd7-5bea91b4916f.yaml
@@ -157,7 +157,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '478'
   notes: []
@@ -210,7 +209,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '478'
   notes: []

--- a/geolexica-v2/9325e8d4-34c1-5ce9-b69a-9f3ee25cb2d1.yaml
+++ b/geolexica-v2/9325e8d4-34c1-5ce9-b69a-9f3ee25cb2d1.yaml
@@ -88,7 +88,6 @@ data:
   dates:
   - date: '2014-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1432'
   notes:

--- a/geolexica-v2/93468ceb-937a-5e1f-948b-9581956752b8.yaml
+++ b/geolexica-v2/93468ceb-937a-5e1f-948b-9581956752b8.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: licence extents
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -73,7 +73,7 @@ data:
   - type: expression
     designation: 허가증 범위
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -108,7 +108,7 @@ data:
   - type: expression
     designation: лицензионное пространство
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -143,7 +143,7 @@ data:
   - type: expression
     designation: ámbito de licencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/9432d2e7-752b-5fa4-aeb1-3d89a8339070.yaml
+++ b/geolexica-v2/9432d2e7-752b-5fa4-aeb1-3d89a8339070.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: joint ownership
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: 공동 소유
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -120,7 +120,7 @@ data:
   - type: expression
     designation: perkongsian milik
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -159,7 +159,7 @@ data:
   - type: expression
     designation: совместное владение
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -198,7 +198,7 @@ data:
   - type: expression
     designation: copropiedad
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/96301396-520f-5ceb-973f-73ecd8d753c5.yaml
+++ b/geolexica-v2/96301396-520f-5ceb-973f-73ecd8d753c5.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: necessary
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: 필연성
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -110,7 +110,7 @@ data:
   - type: expression
     designation: необходимость
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -146,7 +146,7 @@ data:
   - type: expression
     designation: necesario
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/9643f738-67a4-5bd9-8e2f-4c27f1b096d8.yaml
+++ b/geolexica-v2/9643f738-67a4-5bd9-8e2f-4c27f1b096d8.yaml
@@ -49,7 +49,7 @@ data:
   - type: expression
     designation: data quality overview element
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -84,7 +84,7 @@ data:
   - type: expression
     designation: عنصر الاستعراض العام لجودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -121,7 +121,7 @@ data:
   - type: expression
     designation: 数据质量概述元素
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -159,7 +159,7 @@ data:
   - type: expression
     designation: datakvalitet, element til at få overblik over
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -196,7 +196,7 @@ data:
   - type: expression
     designation: kuvaileva laatutekijä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -232,7 +232,7 @@ data:
   - type: expression
     designation: élément d'aperçu de la qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -246,7 +246,6 @@ data:
     type: accepted
   - date: '2014-11-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '116'
   notes:
@@ -269,7 +268,7 @@ data:
   - type: expression
     designation: Überblickselement für die Datenqualität
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -306,7 +305,7 @@ data:
   - type: expression
     designation: 데이터 품질 개관 요소
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -344,7 +343,7 @@ data:
   - type: expression
     designation: описательный элемент качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19101-1:2014
@@ -383,7 +382,7 @@ data:
   - type: expression
     designation: elemento general de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -423,7 +422,7 @@ data:
   - type: expression
     designation: datakvalitetsbeskrivning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014

--- a/geolexica-v2/964a1c4d-8687-5b2d-8b92-0203945a57fd.yaml
+++ b/geolexica-v2/964a1c4d-8687-5b2d-8b92-0203945a57fd.yaml
@@ -206,7 +206,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '133'
   notes:

--- a/geolexica-v2/9666d460-5725-52fe-8c06-7af7341ffe03.yaml
+++ b/geolexica-v2/9666d460-5725-52fe-8c06-7af7341ffe03.yaml
@@ -355,7 +355,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '55'
   notes:

--- a/geolexica-v2/966a60d6-4e52-575b-bbb9-2296d9fe8cf7.yaml
+++ b/geolexica-v2/966a60d6-4e52-575b-bbb9-2296d9fe8cf7.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: population
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: مجموع
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 总体
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: perusjoukko
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -186,7 +186,7 @@ data:
   - type: expression
     designation: population
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -200,7 +200,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: All points in a dataset.
   - content: Names of all roads in a certain geographic area.
@@ -221,7 +220,7 @@ data:
   - type: expression
     designation: Grundgesamtheit
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -257,7 +256,7 @@ data:
   - type: expression
     designation: 모집단
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -293,7 +292,7 @@ data:
   - type: expression
     designation: популяция
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -328,7 +327,7 @@ data:
   - type: expression
     designation: población
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/97d68ff0-43f9-52dd-a029-b05cd049fca6.yaml
+++ b/geolexica-v2/97d68ff0-43f9-52dd-a029-b05cd049fca6.yaml
@@ -76,7 +76,6 @@ data:
   dates:
   - date: '2014-04-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1649'
   notes: []

--- a/geolexica-v2/97e76148-a1fe-542b-ac1c-30f04c8ee55d.yaml
+++ b/geolexica-v2/97e76148-a1fe-542b-ac1c-30f04c8ee55d.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: bypass
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -84,7 +84,7 @@ data:
   - type: expression
     designation: 우회
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -125,7 +125,7 @@ data:
   - type: expression
     designation: bypass(обход)
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -167,7 +167,7 @@ data:
   - type: expression
     designation: bypass
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -208,7 +208,7 @@ data:
   - type: expression
     designation: kringgående
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/9847278c-eec6-5330-acb4-1b6d2cdea06e.yaml
+++ b/geolexica-v2/9847278c-eec6-5330-acb4-1b6d2cdea06e.yaml
@@ -94,7 +94,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '895'
   notes: []

--- a/geolexica-v2/98d0271a-83d0-56c0-b084-69e563da2825.yaml
+++ b/geolexica-v2/98d0271a-83d0-56c0-b084-69e563da2825.yaml
@@ -68,7 +68,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '646'
   notes: []

--- a/geolexica-v2/98f66524-f82d-5602-b678-921964f68767.yaml
+++ b/geolexica-v2/98f66524-f82d-5602-b678-921964f68767.yaml
@@ -34,7 +34,7 @@ data:
   - type: expression
     designation: term instance classification
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -63,7 +63,7 @@ data:
   - type: expression
     designation: تصنيف مثال المصطلح
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -92,7 +92,7 @@ data:
   - type: expression
     designation: 용어 사례 분류
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -149,7 +149,7 @@ data:
   - type: expression
     designation: clasificación de instancias de términos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -178,7 +178,7 @@ data:
   - type: expression
     designation: term instance classification
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016

--- a/geolexica-v2/990dca78-5016-598f-8916-150d1f7f2398.yaml
+++ b/geolexica-v2/990dca78-5016-598f-8916-150d1f7f2398.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2012-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: "“Recreation area” is a land use term that can be applicable to different
       land cover types, e.g. sandy surfaces such as a beach; a built-up area such

--- a/geolexica-v2/992e4007-90b5-5e2a-b8e1-3046d2417d22.yaml
+++ b/geolexica-v2/992e4007-90b5-5e2a-b8e1-3046d2417d22.yaml
@@ -77,7 +77,6 @@ data:
   dates:
   - date: '2012-12-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: A dashed line symbol with a point symbol repeated at an interval.
   id: '1512'

--- a/geolexica-v2/9aa4c89a-c4d2-528d-a69f-ce6b1f385c01.yaml
+++ b/geolexica-v2/9aa4c89a-c4d2-528d-a69f-ce6b1f385c01.yaml
@@ -243,7 +243,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '207'
   notes: []
@@ -314,7 +313,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '207'
   notes: []

--- a/geolexica-v2/9b2fd6d0-9e58-506a-9abd-7ff608d58059.yaml
+++ b/geolexica-v2/9b2fd6d0-9e58-506a-9abd-7ff608d58059.yaml
@@ -197,7 +197,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '665'
   notes:

--- a/geolexica-v2/9bb21db1-7b09-5f28-9dd2-56788403ac5f.yaml
+++ b/geolexica-v2/9bb21db1-7b09-5f28-9dd2-56788403ac5f.yaml
@@ -126,7 +126,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '66'
   notes: []
@@ -197,7 +196,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '66'
   notes: []

--- a/geolexica-v2/9bf182b4-45fe-52ad-a322-0ee8e298b51b.yaml
+++ b/geolexica-v2/9bf182b4-45fe-52ad-a322-0ee8e298b51b.yaml
@@ -345,7 +345,7 @@ data:
   - type: expression
     designation: точность
   language_code: rus
-  entry_status: замененный
+  entry_status: superseded
   review_date: '2007-12-07T00:00:00+05:00'
   review_decision_date: '2008-05-22T00:00:00+00:00'
   review_decision_event: результат FDIS голосования по  ISO 6709:2008

--- a/geolexica-v2/9ccef825-5c9e-590b-af22-e50f3df57856.yaml
+++ b/geolexica-v2/9ccef825-5c9e-590b-af22-e50f3df57856.yaml
@@ -48,7 +48,7 @@ data:
   - type: expression
     designation: product specification
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -82,7 +82,7 @@ data:
   - type: expression
     designation: مواصفات المنتج
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -118,7 +118,7 @@ data:
   - type: expression
     designation: 产品规范
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -157,7 +157,7 @@ data:
   - type: expression
     designation: tuoteseloste
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -194,7 +194,7 @@ data:
   - type: expression
     designation: spécification de produit
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -208,7 +208,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '355'
   notes: []
@@ -229,7 +228,7 @@ data:
   - type: expression
     designation: Produktspezifikation
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -265,7 +264,7 @@ data:
   - type: expression
     designation: 製品仕様
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -301,7 +300,7 @@ data:
   - type: expression
     designation: 제품 사양
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -374,7 +373,7 @@ data:
   - type: expression
     designation: спецификация продукта
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -411,7 +410,7 @@ data:
   - type: expression
     designation: especificaciones de producto
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/9d23a246-6d41-580f-b80c-a3b03ee7a8be.yaml
+++ b/geolexica-v2/9d23a246-6d41-580f-b80c-a3b03ee7a8be.yaml
@@ -204,7 +204,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '473'
   notes: []

--- a/geolexica-v2/9d446efc-32d9-5f1b-8008-6a8c78243202.yaml
+++ b/geolexica-v2/9d446efc-32d9-5f1b-8008-6a8c78243202.yaml
@@ -247,7 +247,6 @@ data:
     type: accepted
   - date: '2015-07-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '726'
   notes:
@@ -315,7 +314,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '726'
   notes:

--- a/geolexica-v2/9dc79397-791f-53cb-8ae7-b53725bd6616.yaml
+++ b/geolexica-v2/9dc79397-791f-53cb-8ae7-b53725bd6616.yaml
@@ -233,7 +233,7 @@ data:
   - type: expression
     designation: качество
   language_code: rus
-  entry_status: замененный
+  entry_status: superseded
   review_date: '2011-04-12T00:00:00+05:00'
   review_decision_date: '2011-04-27T00:00:00+00:00'
   review_decision_event: Голосование по электронной почте группой TMG

--- a/geolexica-v2/9df9d72c-bb92-52bc-8bb5-842b9aebfcd7.yaml
+++ b/geolexica-v2/9df9d72c-bb92-52bc-8bb5-842b9aebfcd7.yaml
@@ -75,7 +75,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '815'
   notes:

--- a/geolexica-v2/9e9977ad-0397-56b2-a0cd-fb836235f898.yaml
+++ b/geolexica-v2/9e9977ad-0397-56b2-a0cd-fb836235f898.yaml
@@ -323,7 +323,6 @@ data:
   dates:
   - date: '2007-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '711'
   notes:

--- a/geolexica-v2/9ef35337-ce34-5efb-888a-6174953d5e24.yaml
+++ b/geolexica-v2/9ef35337-ce34-5efb-888a-6174953d5e24.yaml
@@ -267,7 +267,6 @@ data:
   dates:
   - date: '2008-07-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '733'
   notes: []

--- a/geolexica-v2/a03a7513-1c43-5658-bdf3-833e1438072a.yaml
+++ b/geolexica-v2/a03a7513-1c43-5658-bdf3-833e1438072a.yaml
@@ -381,7 +381,7 @@ data:
   - type: expression
     designation: ресурс
   language_code: rus
-  entry_status: замененный
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19115-1:2014

--- a/geolexica-v2/a0df5034-51b7-5f17-8737-40f0511ff0d4.yaml
+++ b/geolexica-v2/a0df5034-51b7-5f17-8737-40f0511ff0d4.yaml
@@ -48,7 +48,7 @@ data:
   - type: expression
     designation: portrayal rule
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: قاعدة العرض
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -117,7 +117,7 @@ data:
   - type: expression
     designation: 图示表达规则
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -153,7 +153,7 @@ data:
   - type: expression
     designation: esitystapasääntö
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: règle de représentation
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -227,7 +227,7 @@ data:
   - type: expression
     designation: Darstellungsregel
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -263,7 +263,7 @@ data:
   - type: expression
     designation: 묘화 규칙
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -336,7 +336,7 @@ data:
   - type: expression
     designation: правило графического отображения
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19117:2012
@@ -373,7 +373,7 @@ data:
   - type: expression
     designation: regla de representación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -410,7 +410,7 @@ data:
   - type: expression
     designation: visualiseringsregel
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012

--- a/geolexica-v2/a128f180-03f3-51e6-b041-c57be452cb5d.yaml
+++ b/geolexica-v2/a128f180-03f3-51e6-b041-c57be452cb5d.yaml
@@ -71,7 +71,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '850'
   notes:

--- a/geolexica-v2/a181ac9a-679e-59c6-8de8-6f32e5d5ead1.yaml
+++ b/geolexica-v2/a181ac9a-679e-59c6-8de8-6f32e5d5ead1.yaml
@@ -193,7 +193,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '294'
   notes: []

--- a/geolexica-v2/a1b4bd2a-23ad-56a8-b2ba-392d0b20e997.yaml
+++ b/geolexica-v2/a1b4bd2a-23ad-56a8-b2ba-392d0b20e997.yaml
@@ -202,7 +202,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '195'
   notes:

--- a/geolexica-v2/a23acf36-37e9-5e8b-bee7-aa9d0dfb9da3.yaml
+++ b/geolexica-v2/a23acf36-37e9-5e8b-bee7-aa9d0dfb9da3.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: payment provider
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: 지불 제공자
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -117,7 +117,7 @@ data:
   - type: expression
     designation: поставщик платежей
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -153,7 +153,7 @@ data:
   - type: expression
     designation: proveedor de pago
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/a2c58acb-45c7-5df6-8155-c814a639f636.yaml
+++ b/geolexica-v2/a2c58acb-45c7-5df6-8155-c814a639f636.yaml
@@ -278,7 +278,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '212'
   notes:

--- a/geolexica-v2/a3289416-d03c-5aa8-b0e3-1e6abbeb5b17.yaml
+++ b/geolexica-v2/a3289416-d03c-5aa8-b0e3-1e6abbeb5b17.yaml
@@ -156,7 +156,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '740'
   notes: []

--- a/geolexica-v2/a3c86d69-0477-54a2-8ff1-49d8c77ab8f4.yaml
+++ b/geolexica-v2/a3c86d69-0477-54a2-8ff1-49d8c77ab8f4.yaml
@@ -49,7 +49,7 @@ data:
   - type: expression
     designation: data quality subelement
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -82,7 +82,7 @@ data:
   - type: expression
     designation: العنصر الفرعي لجودة البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -118,7 +118,7 @@ data:
   - type: expression
     designation: 数据质量子元素
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -155,7 +155,7 @@ data:
   - type: expression
     designation: datakvalitetsdelelement
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -192,7 +192,7 @@ data:
   - type: expression
     designation: mitattavan laatutekijän osatekijä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -229,7 +229,7 @@ data:
   - type: expression
     designation: sous-élément de qualité des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -243,7 +243,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '119'
   notes: []
@@ -264,7 +263,7 @@ data:
   - type: expression
     designation: Unterelement zur Angabe der Datenqualität
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -300,7 +299,7 @@ data:
   - type: expression
     designation: データ品質副要素
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -336,7 +335,7 @@ data:
   - type: expression
     designation: 데이터 품질 하위 요소
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -409,7 +408,7 @@ data:
   - type: expression
     designation: подэлемент качества данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -446,7 +445,7 @@ data:
   - type: expression
     designation: subelemento de la calidad de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/a4e37a62-5dfa-5917-b887-6252168b70fb.yaml
+++ b/geolexica-v2/a4e37a62-5dfa-5917-b887-6252168b70fb.yaml
@@ -95,7 +95,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '900'
   notes:

--- a/geolexica-v2/a4f5115a-681f-5fbe-b0d9-11de2d054ca4.yaml
+++ b/geolexica-v2/a4f5115a-681f-5fbe-b0d9-11de2d054ca4.yaml
@@ -176,7 +176,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '994'
   notes:

--- a/geolexica-v2/a5fbf285-48a4-53c5-9d98-9874576f2a91.yaml
+++ b/geolexica-v2/a5fbf285-48a4-53c5-9d98-9874576f2a91.yaml
@@ -69,7 +69,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '849'
   notes: []

--- a/geolexica-v2/a606bc04-76d0-5889-9ee7-88802ea64731.yaml
+++ b/geolexica-v2/a606bc04-76d0-5889-9ee7-88802ea64731.yaml
@@ -69,7 +69,6 @@ data:
   dates:
   - date: '2009-04-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '918'
   notes:

--- a/geolexica-v2/a6224551-df03-5e58-8c33-dbad999abab8.yaml
+++ b/geolexica-v2/a6224551-df03-5e58-8c33-dbad999abab8.yaml
@@ -77,7 +77,6 @@ data:
   dates:
   - date: '2014-01-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1414'
   notes: []

--- a/geolexica-v2/a6232792-f5d1-555b-a690-8918da092580.yaml
+++ b/geolexica-v2/a6232792-f5d1-555b-a690-8918da092580.yaml
@@ -161,7 +161,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '678'
   notes: []

--- a/geolexica-v2/a623ed6c-01e3-5005-872c-3963a8262eb1.yaml
+++ b/geolexica-v2/a623ed6c-01e3-5005-872c-3963a8262eb1.yaml
@@ -152,7 +152,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '679'
   notes: []

--- a/geolexica-v2/a69d08ba-b09b-5419-9d94-eeb4e75383f0.yaml
+++ b/geolexica-v2/a69d08ba-b09b-5419-9d94-eeb4e75383f0.yaml
@@ -93,7 +93,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '865'
   notes:

--- a/geolexica-v2/a775bc57-4bad-562b-ae9b-6ac77d05797e.yaml
+++ b/geolexica-v2/a775bc57-4bad-562b-ae9b-6ac77d05797e.yaml
@@ -205,7 +205,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '211'
   notes: []

--- a/geolexica-v2/a79caaed-a21d-54fd-83f2-211530d3f877.yaml
+++ b/geolexica-v2/a79caaed-a21d-54fd-83f2-211530d3f877.yaml
@@ -256,7 +256,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '86'
   notes:

--- a/geolexica-v2/a7ff5a0d-90eb-5c45-82e6-6994cc30589c.yaml
+++ b/geolexica-v2/a7ff5a0d-90eb-5c45-82e6-6994cc30589c.yaml
@@ -42,7 +42,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -74,7 +74,7 @@ data:
   - type: abbreviation
     designation: ن ت ا
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -105,7 +105,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: testattavana oleva järjestelmä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -165,7 +165,7 @@ data:
   - type: expression
     designation: système soumis à test
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -197,7 +197,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -228,7 +228,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -259,7 +259,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -291,7 +291,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -321,7 +321,7 @@ data:
   - type: expression
     designation: Sistema Bajo Prueba
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -353,7 +353,7 @@ data:
   - type: abbreviation
     designation: SUT
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/a8062502-65ad-5a6d-8004-d22c73586718.yaml
+++ b/geolexica-v2/a8062502-65ad-5a6d-8004-d22c73586718.yaml
@@ -253,7 +253,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '138'
   notes:

--- a/geolexica-v2/a87e40ed-86c1-5119-938c-97cee6ecb07f.yaml
+++ b/geolexica-v2/a87e40ed-86c1-5119-938c-97cee6ecb07f.yaml
@@ -293,7 +293,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '104'
   notes: []

--- a/geolexica-v2/a890e1ae-8c32-53fb-8e94-aaa11afad2da.yaml
+++ b/geolexica-v2/a890e1ae-8c32-53fb-8e94-aaa11afad2da.yaml
@@ -420,7 +420,7 @@ data:
   - type: expression
     designation: метаданные
   language_code: rus
-  entry_status: замененный
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19115-1:2014

--- a/geolexica-v2/a9639587-d01d-5d90-bf69-7388fba3a261.yaml
+++ b/geolexica-v2/a9639587-d01d-5d90-bf69-7388fba3a261.yaml
@@ -233,7 +233,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '44'
   notes:

--- a/geolexica-v2/a9fe70dc-e005-5bf1-8b01-eb6a8b0972b6.yaml
+++ b/geolexica-v2/a9fe70dc-e005-5bf1-8b01-eb6a8b0972b6.yaml
@@ -172,7 +172,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '744'
   notes:

--- a/geolexica-v2/aa451d62-2424-5cce-ba9e-bede5546bd48.yaml
+++ b/geolexica-v2/aa451d62-2424-5cce-ba9e-bede5546bd48.yaml
@@ -99,7 +99,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '793'
   notes:

--- a/geolexica-v2/aa827a3a-949f-5229-98e8-d94c8187774b.yaml
+++ b/geolexica-v2/aa827a3a-949f-5229-98e8-d94c8187774b.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: full inspection
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: الفحص الشامل
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -118,7 +118,7 @@ data:
   - type: expression
     designation: 全检
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -155,7 +155,7 @@ data:
   - type: expression
     designation: fuldstændig undersøgelse
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -195,7 +195,7 @@ data:
   - type: expression
     designation: kokonaistutkimus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -231,7 +231,7 @@ data:
   - type: expression
     designation: inspection complète
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -245,7 +245,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '189'
   notes:
@@ -267,7 +266,7 @@ data:
   - type: expression
     designation: vollständige Untersuchung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -304,7 +303,7 @@ data:
   - type: expression
     designation: 전수 검사
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -341,7 +340,7 @@ data:
   - type: expression
     designation: полная проверка
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -378,7 +377,7 @@ data:
   - type: expression
     designation: inspección completa
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -415,7 +414,7 @@ data:
   - type: expression
     designation: fullständig kontroll
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19118:2011

--- a/geolexica-v2/aaee7a7a-7255-5f1c-b12a-612e76c0cbbf.yaml
+++ b/geolexica-v2/aaee7a7a-7255-5f1c-b12a-612e76c0cbbf.yaml
@@ -46,7 +46,7 @@ data:
   - type: expression
     designation: data level
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: مستوى البيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -115,7 +115,7 @@ data:
   - type: expression
     designation: 数据层
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -151,7 +151,7 @@ data:
   - type: expression
     designation: dataniveau
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -187,7 +187,7 @@ data:
   - type: expression
     designation: tietotaso
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -223,7 +223,7 @@ data:
   - type: expression
     designation: niveau des données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -237,7 +237,6 @@ data:
     type: accepted
   - date: '2014-11-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '108'
   notes: []
@@ -258,7 +257,7 @@ data:
   - type: expression
     designation: Datenebene
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -296,7 +295,7 @@ data:
   - type: expression
     designation: 데이터 레벨
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014
@@ -332,7 +331,7 @@ data:
   - type: expression
     designation: уровень данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО19101-1:2014
@@ -368,7 +367,7 @@ data:
   - type: expression
     designation: nivel de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-12T00:00:00+05:00'
   review_decision_date: '2014-11-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19101-1:2014

--- a/geolexica-v2/aafede96-259a-55e5-8785-4348c14097c7.yaml
+++ b/geolexica-v2/aafede96-259a-55e5-8785-4348c14097c7.yaml
@@ -96,7 +96,6 @@ data:
     type: accepted
   - date: '2018-06-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '884'
   notes:

--- a/geolexica-v2/ab506964-b971-59cd-b749-29520385646f.yaml
+++ b/geolexica-v2/ab506964-b971-59cd-b749-29520385646f.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '881'
   notes: []

--- a/geolexica-v2/ab6c7169-5276-5664-9da9-29d45d6462a9.yaml
+++ b/geolexica-v2/ab6c7169-5276-5664-9da9-29d45d6462a9.yaml
@@ -283,7 +283,6 @@ data:
   dates:
   - date: '2003-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: "'Spain' is an example of a country name, 'SW1P 3AD' is an example of
       a postcode."

--- a/geolexica-v2/ac73f7ba-c27f-5d64-b364-42765ee77da6.yaml
+++ b/geolexica-v2/ac73f7ba-c27f-5d64-b364-42765ee77da6.yaml
@@ -42,7 +42,7 @@ data:
   - type: abbreviation
     designation: DRM
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -78,7 +78,7 @@ data:
   - type: expression
     designation: 디지털 저작권 관리
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -131,7 +131,7 @@ data:
   - type: abbreviation
     designation: DRM
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -184,7 +184,7 @@ data:
   - type: abbreviation
     designation: DRM
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/adb68dcb-1cb9-5793-b2c9-7fa392dd468a.yaml
+++ b/geolexica-v2/adb68dcb-1cb9-5793-b2c9-7fa392dd468a.yaml
@@ -184,7 +184,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '127'
   notes: []
@@ -266,7 +265,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '127'
   notes: []

--- a/geolexica-v2/aee3eed5-1482-5b21-9171-275f72e81d4e.yaml
+++ b/geolexica-v2/aee3eed5-1482-5b21-9171-275f72e81d4e.yaml
@@ -186,7 +186,6 @@ data:
   dates:
   - date: '2005-10-17T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '661'
   notes: []

--- a/geolexica-v2/af19328a-95c9-5eb6-a7a5-ca391b8d15b3.yaml
+++ b/geolexica-v2/af19328a-95c9-5eb6-a7a5-ca391b8d15b3.yaml
@@ -202,7 +202,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '238'
   notes: []

--- a/geolexica-v2/af3e5e8a-5e27-537f-9662-0c29103ecd52.yaml
+++ b/geolexica-v2/af3e5e8a-5e27-537f-9662-0c29103ecd52.yaml
@@ -206,7 +206,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: Compact disc, internet [1], radio waves, etc.
   id: '287'

--- a/geolexica-v2/afd04348-0def-5a80-abd7-039b09a5215a.yaml
+++ b/geolexica-v2/afd04348-0def-5a80-abd7-039b09a5215a.yaml
@@ -241,7 +241,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '240'
   notes: []

--- a/geolexica-v2/affc2e54-250c-5a18-a5ef-6922a97f666b.yaml
+++ b/geolexica-v2/affc2e54-250c-5a18-a5ef-6922a97f666b.yaml
@@ -50,7 +50,7 @@ data:
   - type: expression
     designation: dataset series
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -87,7 +87,7 @@ data:
   - type: expression
     designation: سلسلة مجموعة بيانات
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -124,7 +124,7 @@ data:
   - type: expression
     designation: 数据集系列
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -161,7 +161,7 @@ data:
   - type: expression
     designation: datasætserie
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -198,7 +198,7 @@ data:
   - type: expression
     designation: tietoaineistosarja
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -235,7 +235,7 @@ data:
   - type: expression
     designation: série de jeux de données
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -272,7 +272,7 @@ data:
   - type: expression
     designation: Serie von Datensätzen
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -309,7 +309,7 @@ data:
   - type: expression
     designation: データ集合系列
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -346,7 +346,7 @@ data:
   - type: expression
     designation: 데이터셋 시리즈
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -382,7 +382,7 @@ data:
   - type: expression
     designation: siri data
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -455,7 +455,7 @@ data:
   - type: expression
     designation: комплект наборов данных
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19115-1:2014
@@ -493,7 +493,7 @@ data:
   - type: expression
     designation: serie de conjuntos de datos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014
@@ -530,7 +530,7 @@ data:
   - type: expression
     designation: datamängdsserie
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2011-01-01T00:00:00+05:00'
   review_decision_date: '2014-04-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19115-1:2014

--- a/geolexica-v2/b08c1b4f-dd70-5559-88d4-625fd99ee359.yaml
+++ b/geolexica-v2/b08c1b4f-dd70-5559-88d4-625fd99ee359.yaml
@@ -247,7 +247,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '157'
   notes: []

--- a/geolexica-v2/b08d9584-83cc-5eba-8b59-4c63fb96bedb.yaml
+++ b/geolexica-v2/b08d9584-83cc-5eba-8b59-4c63fb96bedb.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: performance testing
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -72,7 +72,7 @@ data:
   - type: expression
     designation: اختبار الأداء
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: 性能测试
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -133,7 +133,7 @@ data:
   - type: expression
     designation: suorituskykytestaus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -163,7 +163,7 @@ data:
   - type: expression
     designation: essais de performance
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -177,7 +177,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '329'
   notes:
@@ -192,7 +191,7 @@ data:
   - type: expression
     designation: Leistungsprüfung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -222,7 +221,7 @@ data:
   - type: expression
     designation: 性能試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -252,7 +251,7 @@ data:
   - type: expression
     designation: 성능 시험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -283,7 +282,7 @@ data:
   - type: expression
     designation: тестирование эффективности
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -314,7 +313,7 @@ data:
   - type: expression
     designation: prueba de desempeño
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -346,7 +345,7 @@ data:
   - type: expression
     designation: prestandatestning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/b2ee52c7-d52f-5b2c-bb58-9a9fcb10b375.yaml
+++ b/geolexica-v2/b2ee52c7-d52f-5b2c-bb58-9a9fcb10b375.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: rights management <GeoDRM>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 권한 관리
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -113,7 +113,7 @@ data:
   - type: expression
     designation: управление правами <GeoDRM>
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -150,7 +150,7 @@ data:
   - type: expression
     designation: gestión de derechos <GeoDRM>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/b37941b9-b1b8-558a-b708-79c21cdba8d4.yaml
+++ b/geolexica-v2/b37941b9-b1b8-558a-b708-79c21cdba8d4.yaml
@@ -247,7 +247,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '489'
   notes:

--- a/geolexica-v2/b383dbc2-81af-503c-ae6a-9f4a026414f3.yaml
+++ b/geolexica-v2/b383dbc2-81af-503c-ae6a-9f4a026414f3.yaml
@@ -247,7 +247,6 @@ data:
     type: accepted
   - date: '2015-12-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '724'
   notes:

--- a/geolexica-v2/b3c53a43-d25d-5fbd-92ce-84ecd938d95f.yaml
+++ b/geolexica-v2/b3c53a43-d25d-5fbd-92ce-84ecd938d95f.yaml
@@ -216,7 +216,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '304'
   notes:

--- a/geolexica-v2/b4dbd477-453c-5e65-9d80-a85ffbd4beea.yaml
+++ b/geolexica-v2/b4dbd477-453c-5e65-9d80-a85ffbd4beea.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: curve segment
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: مقطع منحنى
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -106,7 +106,7 @@ data:
   - type: expression
     designation: 曲线段
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -138,7 +138,7 @@ data:
   - type: expression
     designation: kurvesegment
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -169,7 +169,7 @@ data:
   - type: expression
     designation: käyräsegmentti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -200,7 +200,7 @@ data:
   - type: expression
     designation: segment de courbe
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -214,7 +214,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '102'
   notes:
@@ -230,7 +229,7 @@ data:
   - type: expression
     designation: Kurvenabschnitt
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -260,7 +259,7 @@ data:
   - type: expression
     designation: 曲線分
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -290,7 +289,7 @@ data:
   - type: expression
     designation: 곡선 분절
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -353,7 +352,7 @@ data:
   - type: expression
     designation: сегмент кривой
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -386,7 +385,7 @@ data:
   - type: expression
     designation: segmento de curva
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -416,7 +415,7 @@ data:
   - type: expression
     designation: linjesegment
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/b56e2bc9-1b5d-52a4-8aef-bd78ff4a2aa5.yaml
+++ b/geolexica-v2/b56e2bc9-1b5d-52a4-8aef-bd78ff4a2aa5.yaml
@@ -212,7 +212,6 @@ data:
     type: accepted
   - date: '2015-07-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '432'
   notes:

--- a/geolexica-v2/b758db0e-4296-5642-ae67-28898fc6d59e.yaml
+++ b/geolexica-v2/b758db0e-4296-5642-ae67-28898fc6d59e.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: refinement <UML>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -85,7 +85,7 @@ data:
   - type: expression
     designation: تحسين <UML>
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -123,7 +123,7 @@ data:
   - type: expression
     designation: 细化<UML>
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: tarkennus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -200,7 +200,7 @@ data:
   - type: expression
     designation: raffinement <UML>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -238,7 +238,7 @@ data:
   - type: expression
     designation: 정제 <UML>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -311,7 +311,7 @@ data:
   - type: expression
     designation: refinamiento <UML>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -350,7 +350,7 @@ data:
   - type: expression
     designation: refinement <UML>
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015

--- a/geolexica-v2/b8e58490-725c-5696-af96-37a668202a8a.yaml
+++ b/geolexica-v2/b8e58490-725c-5696-af96-37a668202a8a.yaml
@@ -182,7 +182,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '181'
   notes: []

--- a/geolexica-v2/b9d0287f-18e1-5107-a0c3-541283b9ba43.yaml
+++ b/geolexica-v2/b9d0287f-18e1-5107-a0c3-541283b9ba43.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: bag
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -75,7 +75,7 @@ data:
   - type: expression
     designation: مجموعة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -105,7 +105,7 @@ data:
   - type: expression
     designation: 包
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -136,7 +136,7 @@ data:
   - type: expression
     designation: multimængde
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -168,7 +168,7 @@ data:
   - type: expression
     designation: monijoukko
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -198,7 +198,7 @@ data:
   - type: expression
     designation: sac
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -212,7 +212,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '24'
   notes:
@@ -227,7 +226,7 @@ data:
   - type: expression
     designation: Multimenge
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -257,7 +256,7 @@ data:
   - type: expression
     designation: 多重集合
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -289,7 +288,7 @@ data:
   - type: expression
     designation: 백
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -320,7 +319,7 @@ data:
   - type: expression
     designation: beg
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -382,7 +381,7 @@ data:
   - type: expression
     designation: мультимножество
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -413,7 +412,7 @@ data:
   - type: expression
     designation: bolsa
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -443,7 +442,7 @@ data:
   - type: expression
     designation: bag
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/ba6f36e2-9f67-540b-931b-5ce31247c967.yaml
+++ b/geolexica-v2/ba6f36e2-9f67-540b-931b-5ce31247c967.yaml
@@ -157,7 +157,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '680'
   notes: []

--- a/geolexica-v2/bb18223f-b294-5530-98f4-7d1262ea1c90.yaml
+++ b/geolexica-v2/bb18223f-b294-5530-98f4-7d1262ea1c90.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: catalogue
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-19T00:00:00+05:00'
   review_decision_date: '2023-04-19T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19157-1:2023(E)
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: 목록
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-19T00:00:00+05:00'
   review_decision_date: '2023-04-19T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19157-1:2023(E)
@@ -117,7 +117,7 @@ data:
   - type: expression
     designation: katalog
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-19T00:00:00+05:00'
   review_decision_date: '2023-04-19T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19157-1:2023(E)
@@ -155,7 +155,7 @@ data:
   - type: expression
     designation: каталог
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-19T00:00:00+05:00'
   review_decision_date: '2023-04-19T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19157-1:2023(E)
@@ -193,7 +193,7 @@ data:
   - type: expression
     designation: catálogo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-19T00:00:00+05:00'
   review_decision_date: '2023-04-19T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19157-1:2023(E)
@@ -230,7 +230,7 @@ data:
   - type: expression
     designation: katalog
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-04-19T00:00:00+05:00'
   review_decision_date: '2023-04-19T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19157-1:2023(E)

--- a/geolexica-v2/bb3833af-a297-5604-8b0f-66363aa5729d.yaml
+++ b/geolexica-v2/bb3833af-a297-5604-8b0f-66363aa5729d.yaml
@@ -208,7 +208,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '497'
   notes: []

--- a/geolexica-v2/bb9b2923-231e-50d1-8231-d0dea469df7a.yaml
+++ b/geolexica-v2/bb9b2923-231e-50d1-8231-d0dea469df7a.yaml
@@ -46,7 +46,7 @@ data:
   - type: expression
     designation: computational geometry
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -78,7 +78,7 @@ data:
   - type: expression
     designation: الهندسة الفراغية الحسابية
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -108,7 +108,7 @@ data:
   - type: expression
     designation: 计算几何
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -141,7 +141,7 @@ data:
   - type: expression
     designation: algoritmisk geometri
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -174,7 +174,7 @@ data:
   - type: expression
     designation: laskennallinen geometria
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -204,7 +204,7 @@ data:
   - type: expression
     designation: géométrie calculée
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -218,7 +218,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: Computational geometry operations include testing for geometric inclusion
       or intersection, the calculation of convex hulls or buffer zones, or the finding
@@ -235,7 +234,7 @@ data:
   - type: expression
     designation: algorithmische Geometrie
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -265,7 +264,7 @@ data:
   - type: expression
     designation: 計算幾何
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -296,7 +295,7 @@ data:
   - type: expression
     designation: 계산 기하
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -310,7 +309,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples:
   - content: Computational geometry operations include testing for geometric inclusion
       or intersection, the calculation of convex hulls or buffer zones, or the finding
@@ -327,7 +325,7 @@ data:
   - type: expression
     designation: hitungan geometri
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -393,7 +391,7 @@ data:
   - type: expression
     designation: вычислительная геометрия
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -427,7 +425,7 @@ data:
   - type: expression
     designation: geometría computacional
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -462,7 +460,7 @@ data:
   - type: expression
     designation: beräkningsgeometri
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/bc68143d-9dff-5c01-b2ae-8be8e188752d.yaml
+++ b/geolexica-v2/bc68143d-9dff-5c01-b2ae-8be8e188752d.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: protection
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: 보호
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -85,7 +85,6 @@ data:
     type: accepted
   - date: '2019-08-30T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '1246'
   notes: []
@@ -103,7 +102,7 @@ data:
   - type: expression
     designation: perlindungan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -136,7 +135,7 @@ data:
   - type: expression
     designation: защита
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -170,7 +169,7 @@ data:
   - type: expression
     designation: protección
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/bcb2df8a-29f8-54d8-97c3-4057e9678396.yaml
+++ b/geolexica-v2/bcb2df8a-29f8-54d8-97c3-4057e9678396.yaml
@@ -46,7 +46,7 @@ data:
   - type: expression
     designation: reference data
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: بيانات مرجعية
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 参照数据
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -155,7 +155,7 @@ data:
   - type: expression
     designation: vertaustiedot
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -193,7 +193,7 @@ data:
   - type: expression
     designation: donnée de référence
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -207,7 +207,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '368'
   notes: []
@@ -228,7 +227,7 @@ data:
   - type: expression
     designation: Referenzdaten
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -264,7 +263,7 @@ data:
   - type: expression
     designation: 참조 데이터
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -301,7 +300,7 @@ data:
   - type: expression
     designation: эталонные данные
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -339,7 +338,7 @@ data:
   - type: expression
     designation: datos de referencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/bd6ad901-efcc-581c-ba80-ce17e7c3c47e.yaml
+++ b/geolexica-v2/bd6ad901-efcc-581c-ba80-ce17e7c3c47e.yaml
@@ -239,7 +239,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '49'
   notes: []

--- a/geolexica-v2/be513ef4-9aee-51ea-af5d-082a4921ec9a.yaml
+++ b/geolexica-v2/be513ef4-9aee-51ea-af5d-082a4921ec9a.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: basic test
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: اختبار أساسي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -98,7 +98,7 @@ data:
   - type: expression
     designation: 基本测试
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -128,7 +128,7 @@ data:
   - type: expression
     designation: basistest
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -158,7 +158,7 @@ data:
   - type: expression
     designation: perustesti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: test de base
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -202,7 +202,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '27'
   notes: []
@@ -216,7 +215,7 @@ data:
   - type: expression
     designation: Basistest
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -245,7 +244,7 @@ data:
   - type: expression
     designation: 基本試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -274,7 +273,7 @@ data:
   - type: expression
     designation: 기본 시험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -304,7 +303,7 @@ data:
   - type: expression
     designation: базовый  тест
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -334,7 +333,7 @@ data:
   - type: expression
     designation: prueba básica
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -364,7 +363,7 @@ data:
   - type: expression
     designation: grundtest
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/bf304e68-156b-5fb0-9b77-08fe7e755061.yaml
+++ b/geolexica-v2/bf304e68-156b-5fb0-9b77-08fe7e755061.yaml
@@ -79,7 +79,6 @@ data:
     type: accepted
   - date: '2018-06-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '1279'
   notes: []

--- a/geolexica-v2/bfa19edd-c299-52e2-a2c8-8e5b8cde88e1.yaml
+++ b/geolexica-v2/bfa19edd-c299-52e2-a2c8-8e5b8cde88e1.yaml
@@ -212,7 +212,6 @@ data:
     type: accepted
   - date: '2015-07-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '319'
   notes:

--- a/geolexica-v2/c05aaeea-bd8e-59a8-b685-d9e835ee239e.yaml
+++ b/geolexica-v2/c05aaeea-bd8e-59a8-b685-d9e835ee239e.yaml
@@ -74,7 +74,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '813'
   notes:

--- a/geolexica-v2/c0d4e487-1602-5193-bf41-f17f818635c0.yaml
+++ b/geolexica-v2/c0d4e487-1602-5193-bf41-f17f818635c0.yaml
@@ -99,7 +99,6 @@ data:
     type: accepted
   - date: '2016-10-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '879'
   notes:

--- a/geolexica-v2/c177abb4-3be4-5a26-9278-7162fa367963.yaml
+++ b/geolexica-v2/c177abb4-3be4-5a26-9278-7162fa367963.yaml
@@ -243,7 +243,6 @@ data:
   dates:
   - date: '2005-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '158'
   notes: []

--- a/geolexica-v2/c256897a-e8da-5fdc-90d6-75b472979ea4.yaml
+++ b/geolexica-v2/c256897a-e8da-5fdc-90d6-75b472979ea4.yaml
@@ -222,7 +222,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '186'
   notes: []

--- a/geolexica-v2/c3f5dcb4-ce65-5427-827d-d6e5859ebfc4.yaml
+++ b/geolexica-v2/c3f5dcb4-ce65-5427-827d-d6e5859ebfc4.yaml
@@ -355,7 +355,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '205'
   notes: []

--- a/geolexica-v2/c45a7a35-00b1-5751-b23a-bbabe1b75f73.yaml
+++ b/geolexica-v2/c45a7a35-00b1-5751-b23a-bbabe1b75f73.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: source reference
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: مرجع مصدري
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -99,7 +99,7 @@ data:
   - type: expression
     designation: 出处引用
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -129,7 +129,7 @@ data:
   - type: expression
     designation: lähdeviittaus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -159,7 +159,7 @@ data:
   - type: expression
     designation: référence de la source
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: Quellennachweis
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -217,7 +217,7 @@ data:
   - type: expression
     designation: 출처참조
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -330,7 +330,7 @@ data:
   - type: expression
     designation: referencia de la fuente
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -359,7 +359,7 @@ data:
   - type: expression
     designation: källhänvisning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015

--- a/geolexica-v2/c46fcd87-1111-53db-a8da-b69b2a372cb7.yaml
+++ b/geolexica-v2/c46fcd87-1111-53db-a8da-b69b2a372cb7.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: pass verdict
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -68,7 +68,7 @@ data:
   - type: expression
     designation: حكم اجتياز
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -97,7 +97,7 @@ data:
   - type: expression
     designation: 合格判定
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -128,7 +128,7 @@ data:
   - type: expression
     designation: hyväksyvä päätelmä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -157,7 +157,7 @@ data:
   - type: expression
     designation: verdict de conformité
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -171,7 +171,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '326'
   notes: []
@@ -185,7 +184,7 @@ data:
   - type: expression
     designation: erfolgreicher Prüfnachweis
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -214,7 +213,7 @@ data:
   - type: expression
     designation: 合格判定
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -243,7 +242,7 @@ data:
   - type: expression
     designation: 통과 판정
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -272,7 +271,7 @@ data:
   - type: expression
     designation: положительное заключение
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -301,7 +300,7 @@ data:
   - type: expression
     designation: veredicto de aprobado
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -332,7 +331,7 @@ data:
   - type: expression
     designation: godkänt resultat
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/c487a761-0231-5910-9f19-040b5bd8e8b4.yaml
+++ b/geolexica-v2/c487a761-0231-5910-9f19-040b5bd8e8b4.yaml
@@ -93,7 +93,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '894'
   notes: []

--- a/geolexica-v2/c4b87262-b6d1-5c29-86b7-e8554cf001c9.yaml
+++ b/geolexica-v2/c4b87262-b6d1-5c29-86b7-e8554cf001c9.yaml
@@ -174,7 +174,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '659'
   notes:
@@ -235,7 +234,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '659'
   notes:

--- a/geolexica-v2/c4e81903-40ef-5435-b2c5-eeeeb3058cba.yaml
+++ b/geolexica-v2/c4e81903-40ef-5435-b2c5-eeeeb3058cba.yaml
@@ -157,7 +157,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '446'
   notes: []

--- a/geolexica-v2/c4f8e030-e95e-5b29-ba0c-f68e4428cb81.yaml
+++ b/geolexica-v2/c4f8e030-e95e-5b29-ba0c-f68e4428cb81.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: error
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: خطأ
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 误差
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -154,7 +154,7 @@ data:
   - type: expression
     designation: virheellisyys
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: erreur
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -204,7 +204,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '738'
   notes: []
@@ -225,7 +224,7 @@ data:
   - type: expression
     designation: Fehler
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -263,7 +262,7 @@ data:
   - type: expression
     designation: 에러
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -277,7 +276,6 @@ data:
     type: accepted
   - date: '2013-12-15T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '738'
   notes: []
@@ -298,7 +296,7 @@ data:
   - type: expression
     designation: ralat
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -334,7 +332,7 @@ data:
   - type: expression
     designation: ошибка
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -370,7 +368,7 @@ data:
   - type: expression
     designation: error
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -407,7 +405,7 @@ data:
   - type: expression
     designation: kvantitativ avvikelse
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-12-15T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/c51d983c-8667-5a5d-8ebf-bf7457bc7542.yaml
+++ b/geolexica-v2/c51d983c-8667-5a5d-8ebf-bf7457bc7542.yaml
@@ -259,7 +259,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '136'
   notes:

--- a/geolexica-v2/c51ed30c-c4ad-5151-8572-12473aaa4e7d.yaml
+++ b/geolexica-v2/c51ed30c-c4ad-5151-8572-12473aaa4e7d.yaml
@@ -271,7 +271,6 @@ data:
     type: accepted
   - date: '2019-01-31T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '605'
   notes:

--- a/geolexica-v2/c5eb392c-78d0-5a65-9816-1bf3663c5232.yaml
+++ b/geolexica-v2/c5eb392c-78d0-5a65-9816-1bf3663c5232.yaml
@@ -36,7 +36,7 @@ data:
   - type: expression
     designation: access control
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: 접근 제어
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: контроль доступа
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -135,7 +135,7 @@ data:
   - type: expression
     designation: control de accesos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/c671f1a7-63c3-5c6f-a3f9-96648a69fba9.yaml
+++ b/geolexica-v2/c671f1a7-63c3-5c6f-a3f9-96648a69fba9.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: partitive relation
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: partitive relation
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -95,7 +95,6 @@ data:
     type: accepted
   - date: '2018-06-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '892'
   notes:
@@ -117,7 +116,7 @@ data:
   - type: expression
     designation: partitive relation
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -154,7 +153,7 @@ data:
   - type: expression
     designation: partitive relation
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -192,7 +191,7 @@ data:
   - type: expression
     designation: частичное отношение
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -230,7 +229,7 @@ data:
   - type: expression
     designation: relación partitiva
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -268,7 +267,7 @@ data:
   - type: expression
     designation: partitive relation
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)

--- a/geolexica-v2/c70e0866-4c9c-51bd-b557-6e6473650f2a.yaml
+++ b/geolexica-v2/c70e0866-4c9c-51bd-b557-6e6473650f2a.yaml
@@ -162,7 +162,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '306'
   notes:

--- a/geolexica-v2/c7acdb0f-3e73-59e6-a4f5-d0b07012adeb.yaml
+++ b/geolexica-v2/c7acdb0f-3e73-59e6-a4f5-d0b07012adeb.yaml
@@ -203,7 +203,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '73'
   notes: []

--- a/geolexica-v2/c95d259d-b827-53c9-835c-31e596569def.yaml
+++ b/geolexica-v2/c95d259d-b827-53c9-835c-31e596569def.yaml
@@ -69,7 +69,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '848'
   notes: []
@@ -118,7 +117,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '848'
   notes: []

--- a/geolexica-v2/c99bbb36-df21-5922-b204-acaee2107cbd.yaml
+++ b/geolexica-v2/c99bbb36-df21-5922-b204-acaee2107cbd.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: chain of licence
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: 허가증 사슬
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -111,7 +111,7 @@ data:
   - type: expression
     designation: цепочка лицензий
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -148,7 +148,7 @@ data:
   - type: expression
     designation: cadena de licencias
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/c9f75a32-03c6-5617-93d6-d9c412c4215c.yaml
+++ b/geolexica-v2/c9f75a32-03c6-5617-93d6-d9c412c4215c.yaml
@@ -223,7 +223,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '3'
   notes:

--- a/geolexica-v2/cb8382a8-10d8-56d1-81b4-b9f0c079d2d5.yaml
+++ b/geolexica-v2/cb8382a8-10d8-56d1-81b4-b9f0c079d2d5.yaml
@@ -159,7 +159,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '264'
   notes: []
@@ -241,7 +240,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '264'
   notes: []

--- a/geolexica-v2/cbc0f60e-7896-56f5-adbf-e9a51a484489.yaml
+++ b/geolexica-v2/cbc0f60e-7896-56f5-adbf-e9a51a484489.yaml
@@ -92,7 +92,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '875'
   notes:

--- a/geolexica-v2/cc5550db-f040-5008-b129-206c697e97e6.yaml
+++ b/geolexica-v2/cc5550db-f040-5008-b129-206c697e97e6.yaml
@@ -46,7 +46,7 @@ data:
   - type: expression
     designation: specification <UML>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -84,7 +84,7 @@ data:
   - type: expression
     designation: مواصفات ( UML  )
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -122,7 +122,7 @@ data:
   - type: expression
     designation: 规范
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: spesifikaatio <UML>
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -197,7 +197,7 @@ data:
   - type: expression
     designation: spécification <UML>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -235,7 +235,7 @@ data:
   - type: expression
     designation: 사양 <UML>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -306,7 +306,7 @@ data:
   - type: expression
     designation: especificación <UML>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015
@@ -344,7 +344,7 @@ data:
   - type: expression
     designation: specification <UML>
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-01-14T00:00:00+05:00'
   review_decision_date: '2015-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19103:2015

--- a/geolexica-v2/cce7d6fc-9a81-5386-a90c-b8c7a4372bfd.yaml
+++ b/geolexica-v2/cce7d6fc-9a81-5386-a90c-b8c7a4372bfd.yaml
@@ -166,7 +166,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '667'
   notes:

--- a/geolexica-v2/cd001bce-2e09-5603-a199-73c819b5a891.yaml
+++ b/geolexica-v2/cd001bce-2e09-5603-a199-73c819b5a891.yaml
@@ -199,7 +199,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '258'
   notes: []

--- a/geolexica-v2/cd59cccb-e580-5833-add0-6bf7a86d90f6.yaml
+++ b/geolexica-v2/cd59cccb-e580-5833-add0-6bf7a86d90f6.yaml
@@ -68,7 +68,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '754'
   notes: []

--- a/geolexica-v2/ce799597-6802-5c69-9cf7-9f7519418dfe.yaml
+++ b/geolexica-v2/ce799597-6802-5c69-9cf7-9f7519418dfe.yaml
@@ -236,7 +236,6 @@ data:
   dates:
   - date: '2005-08-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '129'
   notes: []

--- a/geolexica-v2/ce937d2c-7d6c-558a-bf28-003911ee1495.yaml
+++ b/geolexica-v2/ce937d2c-7d6c-558a-bf28-003911ee1495.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: circular sequence
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -73,7 +73,7 @@ data:
   - type: expression
     designation: تسلسل دائري
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: 循环序列
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -133,7 +133,7 @@ data:
   - type: expression
     designation: cirkulær sekvens
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -164,7 +164,7 @@ data:
   - type: expression
     designation: kehäjono
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -195,7 +195,7 @@ data:
   - type: expression
     designation: séquence circulaire
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -209,7 +209,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '41'
   notes: []
@@ -223,7 +222,7 @@ data:
   - type: expression
     designation: Kreissequenz
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -252,7 +251,7 @@ data:
   - type: expression
     designation: 環状列
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -282,7 +281,7 @@ data:
   - type: expression
     designation: 순환 연속
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -343,7 +342,7 @@ data:
   - type: expression
     designation: циклическая [круговая] последовательность
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -374,7 +373,7 @@ data:
   - type: expression
     designation: secuencia circular
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -403,7 +402,7 @@ data:
   - type: expression
     designation: cirkulär sekvens
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/cee4d13a-2c54-5bd9-a92e-e5ee4e666014.yaml
+++ b/geolexica-v2/cee4d13a-2c54-5bd9-a92e-e5ee4e666014.yaml
@@ -77,7 +77,6 @@ data:
   dates:
   - date: '2014-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1460'
   notes:

--- a/geolexica-v2/cf1fda20-6459-576d-8a54-c254afe48751.yaml
+++ b/geolexica-v2/cf1fda20-6459-576d-8a54-c254afe48751.yaml
@@ -215,7 +215,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '348'
   notes:

--- a/geolexica-v2/cf36d03c-e185-5938-ad10-a64f8e6a7f06.yaml
+++ b/geolexica-v2/cf36d03c-e185-5938-ad10-a64f8e6a7f06.yaml
@@ -204,7 +204,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '90'
   notes: []

--- a/geolexica-v2/cf6aa042-fc91-5833-bdba-d767e0e8f68e.yaml
+++ b/geolexica-v2/cf6aa042-fc91-5833-bdba-d767e0e8f68e.yaml
@@ -75,7 +75,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: A curve C with constructive parameter t is a one parameter set of points
       c(t).
@@ -101,7 +100,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: A curve C with constructive parameter t is a one parameter set of points
       c(t).

--- a/geolexica-v2/d030534c-343d-52c6-8a2c-b59ff431ea91.yaml
+++ b/geolexica-v2/d030534c-343d-52c6-8a2c-b59ff431ea91.yaml
@@ -49,7 +49,7 @@ data:
   - type: expression
     designation: locale
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -86,7 +86,7 @@ data:
   - type: expression
     designation: مكان
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -123,7 +123,7 @@ data:
   - type: expression
     designation: "（语）区"
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -161,7 +161,7 @@ data:
   - type: expression
     designation: paikallisuus
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -199,7 +199,7 @@ data:
   - type: expression
     designation: paramétrage (contexte) régional
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -237,7 +237,7 @@ data:
   - type: expression
     designation: Sprachraum
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -274,7 +274,7 @@ data:
   - type: expression
     designation: 현장
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -417,7 +417,7 @@ data:
   - type: expression
     designation: escenario
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015
@@ -461,7 +461,7 @@ data:
   - type: expression
     designation: språkkonvention
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-10-19T00:00:00+05:00'
   review_decision_date: '2015-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19135-1:2015

--- a/geolexica-v2/d0951688-530a-5604-8c12-d884bbe73af1.yaml
+++ b/geolexica-v2/d0951688-530a-5604-8c12-d884bbe73af1.yaml
@@ -314,7 +314,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '151'
   notes: []

--- a/geolexica-v2/d0ea5b88-9a07-57eb-aa4f-5e38d1933001.yaml
+++ b/geolexica-v2/d0ea5b88-9a07-57eb-aa4f-5e38d1933001.yaml
@@ -99,7 +99,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '908'
   notes:

--- a/geolexica-v2/d12f82a6-6cd1-5593-a60f-9bcc941a4f1b.yaml
+++ b/geolexica-v2/d12f82a6-6cd1-5593-a60f-9bcc941a4f1b.yaml
@@ -45,7 +45,7 @@ data:
   - type: expression
     designation: cycle<geometry>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -78,7 +78,7 @@ data:
   - type: expression
     designation: دورة <هندسة>
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -108,7 +108,7 @@ data:
   - type: expression
     designation: 圈
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -141,7 +141,7 @@ data:
   - type: expression
     designation: lukket<geometri>
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -174,7 +174,7 @@ data:
   - type: expression
     designation: silmukka <geometria>
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -203,7 +203,7 @@ data:
   - type: expression
     designation: cycle <géométrie>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -217,7 +217,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '103'
   notes:
@@ -235,7 +234,7 @@ data:
   - type: expression
     designation: Ring <Geometrie>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -265,7 +264,7 @@ data:
   - type: expression
     designation: 輪体
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -296,7 +295,7 @@ data:
   - type: expression
     designation: 순환<기하>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -361,7 +360,7 @@ data:
   - type: expression
     designation: цикл <геометрия>
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -394,7 +393,7 @@ data:
   - type: expression
     designation: ciclo <geometría>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -424,7 +423,7 @@ data:
   - type: expression
     designation: cykliskt objekt
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/d19ad2cf-e9cf-5b4e-8b8f-47d1b4265929.yaml
+++ b/geolexica-v2/d19ad2cf-e9cf-5b4e-8b8f-47d1b4265929.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: abstract test module
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -72,7 +72,7 @@ data:
   - type: expression
     designation: نموذج اختبار تجريدي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -102,7 +102,7 @@ data:
   - type: expression
     designation: 抽象测试模块
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -132,7 +132,7 @@ data:
   - type: expression
     designation: abstrakt testmodul
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: abstrakti testausmoduuli
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -191,7 +191,7 @@ data:
   - type: expression
     designation: module de test abstrait
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -205,7 +205,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '5'
   notes:
@@ -220,7 +219,7 @@ data:
   - type: expression
     designation: abstraktes  Prüfmodul
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -250,7 +249,7 @@ data:
   - type: expression
     designation: 抽象試験モジュール
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -280,7 +279,7 @@ data:
   - type: expression
     designation: 추상 시험 모듈
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -311,7 +310,7 @@ data:
   - type: expression
     designation: модуль  абстрактных тестов
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -342,7 +341,7 @@ data:
   - type: expression
     designation: módulo de pruebas abstractas
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -372,7 +371,7 @@ data:
   - type: expression
     designation: abstrakt testmodul
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/d1b11edc-a282-5669-8405-f482c476b6be.yaml
+++ b/geolexica-v2/d1b11edc-a282-5669-8405-f482c476b6be.yaml
@@ -154,7 +154,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '492'
   notes: []

--- a/geolexica-v2/d25f4a3b-1e0a-54de-a188-0fd948ceb041.yaml
+++ b/geolexica-v2/d25f4a3b-1e0a-54de-a188-0fd948ceb041.yaml
@@ -99,7 +99,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '886'
   notes:

--- a/geolexica-v2/d2f24828-d602-5192-95f1-7adb1fb9085c.yaml
+++ b/geolexica-v2/d2f24828-d602-5192-95f1-7adb1fb9085c.yaml
@@ -234,7 +234,6 @@ data:
   dates:
   - date: '2005-08-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '159'
   notes: []

--- a/geolexica-v2/d4b9244d-36b0-5fbc-a0d1-642cccf410cb.yaml
+++ b/geolexica-v2/d4b9244d-36b0-5fbc-a0d1-642cccf410cb.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: sufficient
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -78,7 +78,7 @@ data:
   - type: expression
     designation: 충분한 것
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -115,7 +115,7 @@ data:
   - type: expression
     designation: mencukupi
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -151,7 +151,7 @@ data:
   - type: expression
     designation: достаточный
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: suficiente
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/d527a0e8-05db-5545-8114-8d83b579ab93.yaml
+++ b/geolexica-v2/d527a0e8-05db-5545-8114-8d83b579ab93.yaml
@@ -178,7 +178,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '308'
   notes:

--- a/geolexica-v2/d5dc840a-8dc2-5ba0-bfc9-cbbac07bada9.yaml
+++ b/geolexica-v2/d5dc840a-8dc2-5ba0-bfc9-cbbac07bada9.yaml
@@ -51,7 +51,7 @@ data:
   - type: abbreviation
     designation: GPL
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -96,7 +96,7 @@ data:
   - type: expression
     designation: 일반 대중 허가증
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -149,7 +149,7 @@ data:
   - type: abbreviation
     designation: GPL
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -198,7 +198,7 @@ data:
   - type: abbreviation
     designation: Licencia Pública General (GPL)
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/d606bdb8-f974-54d7-97b8-ce2f6d2936c4.yaml
+++ b/geolexica-v2/d606bdb8-f974-54d7-97b8-ce2f6d2936c4.yaml
@@ -93,7 +93,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '903'
   notes:

--- a/geolexica-v2/d6179f55-2bbd-5b2c-a398-1b6bac7cf369.yaml
+++ b/geolexica-v2/d6179f55-2bbd-5b2c-a398-1b6bac7cf369.yaml
@@ -176,7 +176,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '331'
   notes: []

--- a/geolexica-v2/d7240675-10ba-5e33-b44d-9a91c83a4de7.yaml
+++ b/geolexica-v2/d7240675-10ba-5e33-b44d-9a91c83a4de7.yaml
@@ -89,7 +89,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '862'
   notes: []

--- a/geolexica-v2/d76c2ea8-520a-5d20-8287-87761641d6d0.yaml
+++ b/geolexica-v2/d76c2ea8-520a-5d20-8287-87761641d6d0.yaml
@@ -159,7 +159,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '972'
   notes: []

--- a/geolexica-v2/d7d676d5-74e1-5e43-bcc0-db8e0a8576df.yaml
+++ b/geolexica-v2/d7d676d5-74e1-5e43-bcc0-db8e0a8576df.yaml
@@ -238,7 +238,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '107'
   notes: []

--- a/geolexica-v2/d8d90e0e-636a-54d0-93f2-d36976f3fbb2.yaml
+++ b/geolexica-v2/d8d90e0e-636a-54d0-93f2-d36976f3fbb2.yaml
@@ -163,7 +163,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1003'
   notes: []

--- a/geolexica-v2/d93542e2-432c-5c3e-816d-fed3f3bc4d00.yaml
+++ b/geolexica-v2/d93542e2-432c-5c3e-816d-fed3f3bc4d00.yaml
@@ -37,7 +37,7 @@ data:
   - type: expression
     designation: risk
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -70,7 +70,7 @@ data:
   - type: expression
     designation: 리스크, 위험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -103,7 +103,7 @@ data:
   - type: expression
     designation: risiko
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -136,7 +136,7 @@ data:
   - type: expression
     designation: риск
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -169,7 +169,7 @@ data:
   - type: expression
     designation: riesgo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/d956cfaa-c5c3-5226-985c-5aeab61575cb.yaml
+++ b/geolexica-v2/d956cfaa-c5c3-5226-985c-5aeab61575cb.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: capability test
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: اختبار القدرة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -100,7 +100,7 @@ data:
   - type: expression
     designation: 能力测试
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -131,7 +131,7 @@ data:
   - type: expression
     designation: egnethedstest
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -162,7 +162,7 @@ data:
   - type: expression
     designation: kelpoisuustesti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -193,7 +193,7 @@ data:
   - type: expression
     designation: test fonctionnel
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -207,7 +207,6 @@ data:
     type: accepted
   - date: '2022-07-06T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '35'
   notes: []
@@ -221,7 +220,7 @@ data:
   - type: expression
     designation: Fähigkeitstest
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -250,7 +249,7 @@ data:
   - type: expression
     designation: 機能試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -280,7 +279,7 @@ data:
   - type: expression
     designation: 기능 시험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -310,7 +309,7 @@ data:
   - type: expression
     designation: тест на функциональное соответствие
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -341,7 +340,7 @@ data:
   - type: expression
     designation: prueba de capacidad
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -372,7 +371,7 @@ data:
   - type: expression
     designation: duglighetstest
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/d95aa0c7-ee6f-5908-966e-6c47952d8266.yaml
+++ b/geolexica-v2/d95aa0c7-ee6f-5908-966e-6c47952d8266.yaml
@@ -286,7 +286,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '196'
   notes: []

--- a/geolexica-v2/da353c07-5485-511c-8ff6-ee6ed7a0389a.yaml
+++ b/geolexica-v2/da353c07-5485-511c-8ff6-ee6ed7a0389a.yaml
@@ -232,7 +232,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '79'
   notes: []

--- a/geolexica-v2/dab3fb21-9f4a-55ca-b753-222c8399c373.yaml
+++ b/geolexica-v2/dab3fb21-9f4a-55ca-b753-222c8399c373.yaml
@@ -38,7 +38,7 @@ data:
   - type: expression
     designation: licensing agent
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: 허가증 에이전트
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -106,7 +106,7 @@ data:
   - type: expression
     designation: агент по лицензированию
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -140,7 +140,7 @@ data:
   - type: expression
     designation: agente de licencias
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/db171dae-8d1d-5f45-8c41-13e419319713.yaml
+++ b/geolexica-v2/db171dae-8d1d-5f45-8c41-13e419319713.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: computational topology
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: الطوبولوجيا الحسابيه
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -103,7 +103,7 @@ data:
   - type: expression
     designation: 计算拓扑
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -134,7 +134,7 @@ data:
   - type: expression
     designation: algoritmisk topologi
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -165,7 +165,7 @@ data:
   - type: expression
     designation: laskennallinen topologia
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -196,7 +196,7 @@ data:
   - type: expression
     designation: topologie calculée
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -210,7 +210,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '62'
   notes: []
@@ -224,7 +223,7 @@ data:
   - type: expression
     designation: algorithmische Topologie
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -253,7 +252,7 @@ data:
   - type: expression
     designation: 計算位相幾何
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -282,7 +281,7 @@ data:
   - type: expression
     designation: 계산 위상
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -296,7 +295,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '62'
   notes: []
@@ -310,7 +308,7 @@ data:
   - type: expression
     designation: hitungan topografi
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -371,7 +369,7 @@ data:
   - type: expression
     designation: вычислительная топология
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -401,7 +399,7 @@ data:
   - type: expression
     designation: topología computacional
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -431,7 +429,7 @@ data:
   - type: expression
     designation: beräkningstopologi
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/db4ac6ad-9b2c-5dd0-93ad-b1c06365cfb8.yaml
+++ b/geolexica-v2/db4ac6ad-9b2c-5dd0-93ad-b1c06365cfb8.yaml
@@ -133,7 +133,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '64'
   notes:

--- a/geolexica-v2/dd48ada5-6b00-5460-a655-627bd5e540e1.yaml
+++ b/geolexica-v2/dd48ada5-6b00-5460-a655-627bd5e540e1.yaml
@@ -160,7 +160,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '274'
   notes:

--- a/geolexica-v2/dd556af7-2a1e-5bdc-9180-e27f7b936647.yaml
+++ b/geolexica-v2/dd556af7-2a1e-5bdc-9180-e27f7b936647.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: linear reference system
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -73,7 +73,7 @@ data:
   - type: expression
     designation: نظام مرجعي طولي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -103,7 +103,7 @@ data:
   - type: expression
     designation: 线性参照系（静态）
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -136,7 +136,7 @@ data:
   - type: expression
     designation: lineaarinen vertausjärjestelmä
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -167,7 +167,7 @@ data:
   - type: expression
     designation: système de référence (référentiel) linéaire
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -181,7 +181,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '272'
   notes:
@@ -197,7 +196,7 @@ data:
   - type: expression
     designation: lineares Referenzsystem
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -227,7 +226,7 @@ data:
   - type: expression
     designation: 선형 참조 체계
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -258,7 +257,7 @@ data:
   - type: expression
     designation: линейная система отсчета
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)
@@ -291,7 +290,7 @@ data:
   - type: expression
     designation: sistema de referencia lineal
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19116:2019(E)

--- a/geolexica-v2/dd603774-2a93-5b5e-a8b0-db23359bb383.yaml
+++ b/geolexica-v2/dd603774-2a93-5b5e-a8b0-db23359bb383.yaml
@@ -43,7 +43,7 @@ data:
   - type: expression
     designation: shell
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: صدفة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -104,7 +104,7 @@ data:
   - type: expression
     designation: 壳
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -134,7 +134,7 @@ data:
   - type: expression
     designation: kuori
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -163,7 +163,7 @@ data:
   - type: expression
     designation: enveloppe surfacique de solide
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -177,7 +177,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '410'
   notes:
@@ -193,7 +192,7 @@ data:
   - type: expression
     designation: Hülle
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -223,7 +222,7 @@ data:
   - type: expression
     designation: 殻
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -253,7 +252,7 @@ data:
   - type: expression
     designation: 외면
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -284,7 +283,7 @@ data:
   - type: expression
     designation: cangkerang;
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -345,7 +344,7 @@ data:
   - type: expression
     designation: оболочка
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -376,7 +375,7 @@ data:
   - type: expression
     designation: envoltura
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)
@@ -407,7 +406,7 @@ data:
   - type: expression
     designation: geometriskt skal
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-12-02T00:00:00+05:00'
   review_decision_date: '2019-12-02T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19107:2019(E)

--- a/geolexica-v2/dea11a95-fe8d-502f-a49c-9277daecafc0.yaml
+++ b/geolexica-v2/dea11a95-fe8d-502f-a49c-9277daecafc0.yaml
@@ -163,7 +163,6 @@ data:
   dates:
   - date: '2010-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '932'
   notes: []

--- a/geolexica-v2/df275290-7a88-5503-829e-4c94e180c6c9.yaml
+++ b/geolexica-v2/df275290-7a88-5503-829e-4c94e180c6c9.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: verification test
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -69,7 +69,7 @@ data:
   - type: expression
     designation: اختبار التحقق
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -98,7 +98,7 @@ data:
   - type: expression
     designation: 验证测试
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -128,7 +128,7 @@ data:
   - type: expression
     designation: todentamistesti
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -158,7 +158,7 @@ data:
   - type: expression
     designation: test de vérification
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -187,7 +187,7 @@ data:
   - type: expression
     designation: 検証試験
   language_code: jpn
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -216,7 +216,7 @@ data:
   - type: expression
     designation: 검증 시험
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -246,7 +246,7 @@ data:
   - type: expression
     designation: ujian pengesahan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -276,7 +276,7 @@ data:
   - type: expression
     designation: удостоверяющий тест
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -305,7 +305,7 @@ data:
   - type: expression
     designation: prueba de verificación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)
@@ -336,7 +336,7 @@ data:
   - type: expression
     designation: verifieringstest
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2022-07-06T00:00:00+05:00'
   review_decision_date: '2022-07-06T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19105:2022(E)

--- a/geolexica-v2/df8e954f-5b4e-5279-a429-c26201ac6d63.yaml
+++ b/geolexica-v2/df8e954f-5b4e-5279-a429-c26201ac6d63.yaml
@@ -169,7 +169,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '658'
   notes:

--- a/geolexica-v2/dfd9987c-7379-5c6e-9507-a42cd5ba4401.yaml
+++ b/geolexica-v2/dfd9987c-7379-5c6e-9507-a42cd5ba4401.yaml
@@ -240,7 +240,6 @@ data:
     type: accepted
   - date: '2019-12-02T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '213'
   notes:

--- a/geolexica-v2/e03cc42d-b346-5067-9541-a55b963ab7f9.yaml
+++ b/geolexica-v2/e03cc42d-b346-5067-9541-a55b963ab7f9.yaml
@@ -47,7 +47,7 @@ data:
   - type: expression
     designation: portrayal catalogue
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -80,7 +80,7 @@ data:
   - type: expression
     designation: كتلوج العرض
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 图示表达目录
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: esitystapaluettelo
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: catalogue de représentations
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -224,7 +224,7 @@ data:
   - type: expression
     designation: Darstellungskatalog
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -260,7 +260,7 @@ data:
   - type: expression
     designation: 묘화 목록
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -331,7 +331,7 @@ data:
   - type: expression
     designation: каталог типов графического отображения
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Публикация ИСО 19117:2012
@@ -367,7 +367,7 @@ data:
   - type: expression
     designation: catálogo de representación
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012
@@ -404,7 +404,7 @@ data:
   - type: expression
     designation: visualiseringskatalog
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2009-11-25T00:00:00+05:00'
   review_decision_date: '2012-12-15T00:00:00+05:00'
   review_decision_event: Publication of ISO 19117:2012

--- a/geolexica-v2/e051b801-751b-5230-8251-d2a7262d31c5.yaml
+++ b/geolexica-v2/e051b801-751b-5230-8251-d2a7262d31c5.yaml
@@ -40,7 +40,7 @@ data:
   - type: expression
     designation: GeoLicence infringement
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -76,7 +76,7 @@ data:
   - type: expression
     designation: 지오허가증 침해
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -114,7 +114,7 @@ data:
   - type: expression
     designation: нарушение геолицензии
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -152,7 +152,7 @@ data:
   - type: expression
     designation: violación de GeoLicencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/e070252a-a8a1-5313-ae35-d25e74a90165.yaml
+++ b/geolexica-v2/e070252a-a8a1-5313-ae35-d25e74a90165.yaml
@@ -316,7 +316,6 @@ data:
   dates:
   - date: '2007-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: Local engineering and architectural grids; coordinate reference system
       local to a ship or an orbiting spacecraft.

--- a/geolexica-v2/e083f951-4491-5da2-9f68-5a93e88dc33d.yaml
+++ b/geolexica-v2/e083f951-4491-5da2-9f68-5a93e88dc33d.yaml
@@ -95,7 +95,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '876'
   notes:

--- a/geolexica-v2/e0924d97-6898-53d2-b445-259e025ec04d.yaml
+++ b/geolexica-v2/e0924d97-6898-53d2-b445-259e025ec04d.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2012-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1178'
   notes:

--- a/geolexica-v2/e1442db1-d4cc-5584-9f42-e5828cb259e6.yaml
+++ b/geolexica-v2/e1442db1-d4cc-5584-9f42-e5828cb259e6.yaml
@@ -95,7 +95,6 @@ data:
   dates:
   - date: '2009-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: A "supports" feature association concept describes a relationship between
       real world phenomena such as "highways" and "bridges" where the role of one

--- a/geolexica-v2/e1859d39-5243-5860-81f8-a16130f07026.yaml
+++ b/geolexica-v2/e1859d39-5243-5860-81f8-a16130f07026.yaml
@@ -39,7 +39,7 @@ data:
   - type: expression
     designation: remediation
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -74,7 +74,7 @@ data:
   - type: expression
     designation: 교정, 개선
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -109,7 +109,7 @@ data:
   - type: expression
     designation: pemulihan
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -144,7 +144,7 @@ data:
   - type: expression
     designation: Исправление
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -179,7 +179,7 @@ data:
   - type: expression
     designation: corrección
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/e1921048-375c-517b-8bdf-66c6838bc2c4.yaml
+++ b/geolexica-v2/e1921048-375c-517b-8bdf-66c6838bc2c4.yaml
@@ -129,7 +129,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '10'
   notes: []

--- a/geolexica-v2/e1a666ef-49f7-5377-a6e2-c4b442fc1a7a.yaml
+++ b/geolexica-v2/e1a666ef-49f7-5377-a6e2-c4b442fc1a7a.yaml
@@ -81,7 +81,6 @@ data:
   dates:
   - date: '2014-01-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1386'
   notes: []

--- a/geolexica-v2/e25bab52-1481-55b9-bb7a-41cbd2824b0d.yaml
+++ b/geolexica-v2/e25bab52-1481-55b9-bb7a-41cbd2824b0d.yaml
@@ -210,7 +210,6 @@ data:
   dates:
   - date: '2005-08-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '491'
   notes:

--- a/geolexica-v2/e27af223-8a62-5c67-af97-acc7b1f2db01.yaml
+++ b/geolexica-v2/e27af223-8a62-5c67-af97-acc7b1f2db01.yaml
@@ -49,7 +49,7 @@ data:
   - type: expression
     designation: conformance quality level
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -87,7 +87,7 @@ data:
   - type: expression
     designation: مستوى جودة المطابقة
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -124,7 +124,7 @@ data:
   - type: expression
     designation: 一致性质量级别
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -163,7 +163,7 @@ data:
   - type: expression
     designation: overensstemmelse, kvalitetsniveau af
   language_code: dan
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -201,7 +201,7 @@ data:
   - type: expression
     designation: laatuvaatimustaso
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -241,7 +241,7 @@ data:
   - type: expression
     designation: niveau de conformité
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -280,7 +280,7 @@ data:
   - type: expression
     designation: Qualitätskonformitätsschwellwert
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -318,7 +318,7 @@ data:
   - type: expression
     designation: 적합성 품질 수준
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -357,7 +357,7 @@ data:
   - type: expression
     designation: уровень соответствия качества
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -397,7 +397,7 @@ data:
   - type: expression
     designation: nivel de calidad de conformidad
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -435,7 +435,7 @@ data:
   - type: expression
     designation: målvärde för datakvalitet
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/e4174f33-aa2c-5f52-b7c6-0828edddf92b.yaml
+++ b/geolexica-v2/e4174f33-aa2c-5f52-b7c6-0828edddf92b.yaml
@@ -153,7 +153,6 @@ data:
   dates:
   - date: '2007-02-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '630'
   notes: []

--- a/geolexica-v2/e4e8e32e-4894-5c61-a827-d6492c7b02af.yaml
+++ b/geolexica-v2/e4e8e32e-4894-5c61-a827-d6492c7b02af.yaml
@@ -226,7 +226,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '43'
   notes:

--- a/geolexica-v2/e52de851-5671-5079-9f2c-c989fde9986b.yaml
+++ b/geolexica-v2/e52de851-5671-5079-9f2c-c989fde9986b.yaml
@@ -268,7 +268,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '48'
   notes:
@@ -382,7 +381,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '48'
   notes:

--- a/geolexica-v2/e5d46a5a-d1b7-582f-ae95-2273e7074f3c.yaml
+++ b/geolexica-v2/e5d46a5a-d1b7-582f-ae95-2273e7074f3c.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: inverse evaluation<coverage>
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -71,7 +71,7 @@ data:
   - type: expression
     designation: تقييم عكسي <تغطية>
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -100,7 +100,7 @@ data:
   - type: expression
     designation: 逆求值<覆盖>
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -130,7 +130,7 @@ data:
   - type: expression
     designation: käänteinen arvonmääritys <paikkatietojakauma>
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -160,7 +160,7 @@ data:
   - type: expression
     designation: évaluation inverse <couverture>
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -190,7 +190,7 @@ data:
   - type: expression
     designation: inverse Evaluierung <Coverage>
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -219,7 +219,7 @@ data:
   - type: expression
     designation: 역산출 <커버리지>
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -248,7 +248,7 @@ data:
   - type: expression
     designation: kesinaran
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -307,7 +307,7 @@ data:
   - type: expression
     designation: обратное оценивание <покрытие>
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -337,7 +337,7 @@ data:
   - type: expression
     designation: evaluación inversa <cobertura>
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)
@@ -367,7 +367,7 @@ data:
   - type: expression
     designation: inverterad domänobjektbestämning
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2023-06-21T00:00:00+05:00'
   review_decision_date: '2023-06-21T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19123-1:2023(E)

--- a/geolexica-v2/e68ad79e-df6a-55ba-acb4-3bdf0bab5360.yaml
+++ b/geolexica-v2/e68ad79e-df6a-55ba-acb4-3bdf0bab5360.yaml
@@ -163,7 +163,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '668'
   notes:

--- a/geolexica-v2/e6bddf57-31f5-55ee-bc3f-a4836e8831f3.yaml
+++ b/geolexica-v2/e6bddf57-31f5-55ee-bc3f-a4836e8831f3.yaml
@@ -42,7 +42,7 @@ data:
   - type: expression
     designation: sublicence
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -79,7 +79,7 @@ data:
   - type: expression
     designation: 2차 허가증, 재실시권
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -118,7 +118,7 @@ data:
   - type: expression
     designation: сублицензия
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -157,7 +157,7 @@ data:
   - type: expression
     designation: sublicencia
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/e7c20724-02a3-53fa-89d3-80cdd794b04c.yaml
+++ b/geolexica-v2/e7c20724-02a3-53fa-89d3-80cdd794b04c.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: party
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -84,7 +84,7 @@ data:
   - type: expression
     designation: party
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -124,7 +124,7 @@ data:
   - type: expression
     designation: party
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -166,7 +166,7 @@ data:
   - type: expression
     designation: сторона
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954
@@ -207,7 +207,7 @@ data:
   - type: expression
     designation: parte
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2019-06-07T00:00:00+05:00'
   review_decision_date: '2019-08-30T00:00:00+05:00'
   review_decision_event: 48th Plenary of ISO/TC 211; Resolution 954

--- a/geolexica-v2/e8014fbc-8ce0-5bc7-b596-fd9a1fec320f.yaml
+++ b/geolexica-v2/e8014fbc-8ce0-5bc7-b596-fd9a1fec320f.yaml
@@ -34,7 +34,7 @@ data:
   - type: expression
     designation: feature relationship
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-01-26T00:00:00+05:00'
   review_decision_date: '2016-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19110:2016
@@ -64,7 +64,7 @@ data:
   - type: expression
     designation: 지형지물
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-01-26T00:00:00+05:00'
   review_decision_date: '2016-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19110:2016
@@ -123,7 +123,7 @@ data:
   - type: expression
     designation: relación de objetos geográficos
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-01-26T00:00:00+05:00'
   review_decision_date: '2016-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19110:2016
@@ -153,7 +153,7 @@ data:
   - type: expression
     designation: objektrelation
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2012-01-26T00:00:00+05:00'
   review_decision_date: '2016-12-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19110:2016

--- a/geolexica-v2/e8411af6-71a2-51ac-827b-4d95ece8facd.yaml
+++ b/geolexica-v2/e8411af6-71a2-51ac-827b-4d95ece8facd.yaml
@@ -194,7 +194,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: Two instances of the feature type "pasture" are replaced by a single
       instance when the fence between the pastures is removed.

--- a/geolexica-v2/e88e1b85-6682-5cf9-8968-5e21d472c054.yaml
+++ b/geolexica-v2/e88e1b85-6682-5cf9-8968-5e21d472c054.yaml
@@ -45,7 +45,7 @@ data:
   - type: expression
     designation: item
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: بند
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -116,7 +116,7 @@ data:
   - type: expression
     designation: 数据项
   language_code: zho
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -154,7 +154,7 @@ data:
   - type: expression
     designation: yksilö
   language_code: fin
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -188,7 +188,7 @@ data:
   - type: expression
     designation: élément
   language_code: fra
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -224,7 +224,7 @@ data:
   - type: expression
     designation: Element
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -259,7 +259,7 @@ data:
   - type: expression
     designation: 항목
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -295,7 +295,7 @@ data:
   - type: expression
     designation: item
   language_code: msa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013
@@ -331,7 +331,7 @@ data:
   - type: expression
     designation: элемент
   language_code: rus
-  entry_status: изъятый
+  entry_status: withdrawn
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Публикация ИСО 19157:2013
@@ -368,7 +368,7 @@ data:
   - type: expression
     designation: ítem
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2010-07-09T00:00:00+05:00'
   review_decision_date: '2013-12-15T00:00:00+00:00'
   review_decision_event: Publication of ISO 19157:2013

--- a/geolexica-v2/e92c4eab-6b33-5237-b855-f04eae669ca1.yaml
+++ b/geolexica-v2/e92c4eab-6b33-5237-b855-f04eae669ca1.yaml
@@ -90,7 +90,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '902'
   notes: []

--- a/geolexica-v2/e9abaf92-46bf-5d8f-8dc9-f2e84f8cb6ff.yaml
+++ b/geolexica-v2/e9abaf92-46bf-5d8f-8dc9-f2e84f8cb6ff.yaml
@@ -220,7 +220,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '328'
   notes:

--- a/geolexica-v2/ea0dd6c4-4457-5edc-a5a0-9172751ca88d.yaml
+++ b/geolexica-v2/ea0dd6c4-4457-5edc-a5a0-9172751ca88d.yaml
@@ -86,7 +86,6 @@ data:
   dates:
   - date: '2009-04-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '916'
   notes:

--- a/geolexica-v2/ebd2a295-b920-5e63-b698-8e81079193d9.yaml
+++ b/geolexica-v2/ebd2a295-b920-5e63-b698-8e81079193d9.yaml
@@ -184,7 +184,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '31'
   notes: []

--- a/geolexica-v2/ee3f1f45-d7d8-5f24-8356-956194784c30.yaml
+++ b/geolexica-v2/ee3f1f45-d7d8-5f24-8356-956194784c30.yaml
@@ -98,7 +98,6 @@ data:
   dates:
   - date: '2010-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '896'
   notes:

--- a/geolexica-v2/ef22e753-22d0-5389-8abf-af9cc59e8deb.yaml
+++ b/geolexica-v2/ef22e753-22d0-5389-8abf-af9cc59e8deb.yaml
@@ -191,7 +191,6 @@ data:
   dates:
   - date: '2002-09-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples:
   - content: An instance of feature type "building" is razed and replaced by an instance
       of feature type "parking lot."

--- a/geolexica-v2/ef5ef866-670c-5c76-a364-5e23c996ef84.yaml
+++ b/geolexica-v2/ef5ef866-670c-5c76-a364-5e23c996ef84.yaml
@@ -161,7 +161,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '672'
   notes:

--- a/geolexica-v2/ef778518-7ea6-5803-877b-f3cb2b5ae561.yaml
+++ b/geolexica-v2/ef778518-7ea6-5803-877b-f3cb2b5ae561.yaml
@@ -202,7 +202,6 @@ data:
   dates:
   - date: '2005-07-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '246'
   notes: []

--- a/geolexica-v2/efae9a02-e7b0-53da-81c8-1357acf98963.yaml
+++ b/geolexica-v2/efae9a02-e7b0-53da-81c8-1357acf98963.yaml
@@ -255,7 +255,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '139'
   notes:

--- a/geolexica-v2/efb99738-de8a-52fe-ba80-c8e1ed2409a0.yaml
+++ b/geolexica-v2/efb99738-de8a-52fe-ba80-c8e1ed2409a0.yaml
@@ -97,7 +97,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '911'
   notes:
@@ -174,7 +173,6 @@ data:
   dates:
   - date: '2008-11-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '911'
   notes:

--- a/geolexica-v2/f19d746f-ab09-5190-9898-417ea9c958f4.yaml
+++ b/geolexica-v2/f19d746f-ab09-5190-9898-417ea9c958f4.yaml
@@ -278,7 +278,6 @@ data:
   dates:
   - date: '2005-06-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '52'
   notes: []

--- a/geolexica-v2/f2589075-e5d8-5506-bf86-d94d605c4fda.yaml
+++ b/geolexica-v2/f2589075-e5d8-5506-bf86-d94d605c4fda.yaml
@@ -134,7 +134,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '640'
   notes:

--- a/geolexica-v2/f30d1c4e-0da0-5ccb-8ebb-319b90995685.yaml
+++ b/geolexica-v2/f30d1c4e-0da0-5ccb-8ebb-319b90995685.yaml
@@ -41,7 +41,7 @@ data:
   - type: expression
     designation: extension
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -75,7 +75,7 @@ data:
   - type: expression
     designation: امتداد
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -89,7 +89,6 @@ data:
     type: accepted
   - date: '2016-10-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '910'
   notes: []
@@ -108,7 +107,7 @@ data:
   - type: expression
     designation: Erweiterung
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -142,7 +141,7 @@ data:
   - type: expression
     designation: 확장
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -237,7 +236,7 @@ data:
   - type: expression
     designation: extensión
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -271,7 +270,7 @@ data:
   - type: expression
     designation: extension
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016

--- a/geolexica-v2/f3f53dd7-474a-5a92-93bd-e45cd7d3cab8.yaml
+++ b/geolexica-v2/f3f53dd7-474a-5a92-93bd-e45cd7d3cab8.yaml
@@ -178,7 +178,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '677'
   notes:

--- a/geolexica-v2/f57fd62e-69eb-57fa-8784-9ec82d5f4666.yaml
+++ b/geolexica-v2/f57fd62e-69eb-57fa-8784-9ec82d5f4666.yaml
@@ -68,7 +68,6 @@ data:
   dates:
   - date: '2009-08-15T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '810'
   notes: []

--- a/geolexica-v2/f65884dd-a2c6-5a42-97cd-81cbbea7e8fd.yaml
+++ b/geolexica-v2/f65884dd-a2c6-5a42-97cd-81cbbea7e8fd.yaml
@@ -234,7 +234,6 @@ data:
   dates:
   - date: '2012-12-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: A condominium unit comprising two spatial units (e.g. an apartment and
       a garage), a farm lot comprising one spatial unit (e.g. parcel of land), a servitude

--- a/geolexica-v2/f822007b-22e1-52b6-be14-526e7055e252.yaml
+++ b/geolexica-v2/f822007b-22e1-52b6-be14-526e7055e252.yaml
@@ -157,7 +157,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '387'
   notes: []
@@ -210,7 +209,6 @@ data:
   dates:
   - date: '2005-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '387'
   notes: []

--- a/geolexica-v2/f8ba9cef-53a4-5d62-aee9-1ea7b82fd6f6.yaml
+++ b/geolexica-v2/f8ba9cef-53a4-5d62-aee9-1ea7b82fd6f6.yaml
@@ -34,7 +34,7 @@ data:
   - type: expression
     designation: terminological record
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -63,7 +63,7 @@ data:
   - type: expression
     designation: سجل مصطلحي
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -92,7 +92,7 @@ data:
   - type: expression
     designation: 용어 기록
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -150,7 +150,7 @@ data:
   - type: expression
     designation: registro terminológico
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016
@@ -179,7 +179,7 @@ data:
   - type: expression
     designation: terminological record
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2013-01-29T00:00:00+05:00'
   review_decision_date: '2016-10-01T00:00:00+05:00'
   review_decision_event: Publication of ISO 19104:2016

--- a/geolexica-v2/f8de7993-114c-5fc9-9809-09c5e7650961.yaml
+++ b/geolexica-v2/f8de7993-114c-5fc9-9809-09c5e7650961.yaml
@@ -261,7 +261,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: A system for identifying relative positions within a few kilometres of
       the reference point.

--- a/geolexica-v2/f9620f40-1f8d-54ea-bdd8-602c26fc6ea7.yaml
+++ b/geolexica-v2/f9620f40-1f8d-54ea-bdd8-602c26fc6ea7.yaml
@@ -231,7 +231,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '259'
   notes:
@@ -345,7 +344,6 @@ data:
   dates:
   - date: '2003-05-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '259'
   notes:

--- a/geolexica-v2/fa2aafdf-2485-5739-9b5e-b0c8764f705c.yaml
+++ b/geolexica-v2/fa2aafdf-2485-5739-9b5e-b0c8764f705c.yaml
@@ -81,7 +81,6 @@ data:
   dates:
   - date: '2014-01-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1393'
   notes: []

--- a/geolexica-v2/fa80b311-7d85-5f40-89f9-293c1cbfa8d8.yaml
+++ b/geolexica-v2/fa80b311-7d85-5f40-89f9-293c1cbfa8d8.yaml
@@ -177,7 +177,6 @@ data:
   dates:
   - date: '2007-10-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '656'
   notes:

--- a/geolexica-v2/fb7bbd85-3d06-5ade-8060-3cb53f636121.yaml
+++ b/geolexica-v2/fb7bbd85-3d06-5ade-8060-3cb53f636121.yaml
@@ -203,7 +203,6 @@ data:
   dates:
   - date: '2002-07-01T00:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '268'
   notes: []

--- a/geolexica-v2/fbebcd28-434a-589c-8a6e-cbf08e3ba681.yaml
+++ b/geolexica-v2/fbebcd28-434a-589c-8a6e-cbf08e3ba681.yaml
@@ -184,7 +184,6 @@ data:
     type: accepted
   - date: '2023-06-21T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '416'
   notes:

--- a/geolexica-v2/fc4de0ff-9b65-5453-a8b3-d1d867d5da82.yaml
+++ b/geolexica-v2/fc4de0ff-9b65-5453-a8b3-d1d867d5da82.yaml
@@ -377,7 +377,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: A system for identifying relative positions within a few kilometres of
       the reference point.

--- a/geolexica-v2/fc5c4362-273e-58fb-84ba-86b4bf19dfcd.yaml
+++ b/geolexica-v2/fc5c4362-273e-58fb-84ba-86b4bf19dfcd.yaml
@@ -292,7 +292,6 @@ data:
   dates:
   - date: '2003-02-15T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '504'
   notes: []

--- a/geolexica-v2/fcd30ca8-47c0-5532-b953-581f1ee07785.yaml
+++ b/geolexica-v2/fcd30ca8-47c0-5532-b953-581f1ee07785.yaml
@@ -211,7 +211,6 @@ data:
   dates:
   - date: '2004-07-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples:
   - content: 'Total Station: Commonly used term for an integrated optical positioning
       system incorporating an electronic theodolite and an electronic distance-measuring

--- a/geolexica-v2/fe026fbf-0b52-5c74-9bae-a6f53245bd84.yaml
+++ b/geolexica-v2/fe026fbf-0b52-5c74-9bae-a6f53245bd84.yaml
@@ -84,7 +84,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '847'
   notes: []
@@ -147,7 +146,6 @@ data:
   dates:
   - date: '2008-06-01T01:00:00+06:00'
     type: accepted
-  definition: []
   examples: []
   id: '847'
   notes: []

--- a/geolexica-v2/fe1c2b3f-2ad5-5387-88d6-3b6dfd6ccb6c.yaml
+++ b/geolexica-v2/fe1c2b3f-2ad5-5387-88d6-3b6dfd6ccb6c.yaml
@@ -76,7 +76,6 @@ data:
   dates:
   - date: '2014-11-01T00:00:00+05:00'
     type: accepted
-  definition: []
   examples: []
   id: '1430'
   notes: []

--- a/geolexica-v2/fe33e413-b65c-5abc-b23a-429a3a3899ac.yaml
+++ b/geolexica-v2/fe33e413-b65c-5abc-b23a-429a3a3899ac.yaml
@@ -44,7 +44,7 @@ data:
   - type: expression
     designation: part-whole relation
   language_code: eng
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -81,7 +81,7 @@ data:
   - type: expression
     designation: part-whole relation
   language_code: ara
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -95,7 +95,6 @@ data:
     type: accepted
   - date: '2018-06-01T00:00:00+05:00'
     type: amended
-  definition: []
   examples: []
   id: '891'
   notes:
@@ -117,7 +116,7 @@ data:
   - type: expression
     designation: part-whole relation
   language_code: deu
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -154,7 +153,7 @@ data:
   - type: expression
     designation: part-whole relation
   language_code: kor
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -192,7 +191,7 @@ data:
   - type: expression
     designation: отношение часть-целое
   language_code: rus
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -230,7 +229,7 @@ data:
   - type: expression
     designation: relación parte-todo
   language_code: spa
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)
@@ -268,7 +267,7 @@ data:
   - type: expression
     designation: part-whole relation
   language_code: swe
-  entry_status: retired
+  entry_status: superseded
   review_date: '2018-06-01T00:00:00+05:00'
   review_decision_date: '2018-06-01T00:00:00+05:00'
   review_decision_event: Publication of documentISO 19146:2018(E)


### PR DESCRIPTION
- Remove empty `definition: []` arrays from 449 concept files
- Map invalid `entry_status` values: `retired`→`superseded`, `изъятый`→`withdrawn`, `замененный`→`superseded`
- Add `build.yml` with `glossarist validate` step
- Switch `publish-gcr.yml` from vocabulary-browser (Node.js) to glossarist Ruby gem
- All 312 concepts now pass `glossarist validate .` with 0 errors